### PR TITLE
Offline context provided during normalization.

### DIFF
--- a/ts/credentials/credential/index.ts
+++ b/ts/credentials/credential/index.ts
@@ -1,26 +1,18 @@
 import { classToPlain, plainToClass } from 'class-transformer'
 import { IClaim, IClaimMetadata, ICredential } from './types'
 
-// TODO REPLACE CONTEXT WITH LOCAL DEFINITON
 export class Credential {
-  private '@context' = [
-    'http://schema.org',
-    'https://w3id.org/credentials/v1'
-  ]
-
+  private '@context': string[] | object[]
   private type: string[]
   private claim: IClaim
 
   public assemble(metadata: IClaimMetadata, value: string, subject: string): Credential {
     const cred = new Credential()
     cred.type = metadata.type
+    cred['@context'] = metadata.context
     cred.claim = {
       id: subject,
       [metadata.fieldName]: value
-    }
-
-    if (metadata.context) {
-      cred['@context'].concat(metadata.context)
     }
 
     return cred
@@ -34,7 +26,7 @@ export class Credential {
     return this.type
   }
 
-  public getContext(): string[] {
+  public getContext(): string[] | object[] {
     return this['@context']
   }
 

--- a/ts/credentials/credential/types.ts
+++ b/ts/credentials/credential/types.ts
@@ -4,16 +4,16 @@ export interface IClaim {
 }
 
 export interface ICredential {
-  '@context': string[]
+  '@context': string[] | object[]
   type: string[]
   name?: string
   claim: IClaim
 }
 
 export interface IClaimMetadata {
-  type: string[]
   fieldName: string
-  context?: string[]
+  type: string[]
+  context: string[] | object[]
   name?: string
 }
 

--- a/ts/credentials/verifiableCredential/types.ts
+++ b/ts/credentials/verifiableCredential/types.ts
@@ -6,5 +6,5 @@ export interface IVerifiableCredential extends ICredential {
   issuer: string
   issued: string
   expires?: string
-  signature: ILinkedDataSignature
+  proof: ILinkedDataSignature
 }

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -21,11 +21,23 @@ export class JolocomLib {
 export const claimsMetadata: IDefaultClaimsMetadata = {
   emailAddress: {
     fieldName: 'email',
-    type: ['Credential', 'EmailAddressCredentail']
+    type: ['Credential'],
+    context: [
+      'https://w3id.org/identity/v1',
+      'https://w3id.org/security/v1',
+      'https://w3id.org/credentials/v1',
+      'http://schema.org'
+    ]
   },
   mobilePhoneNumber: {
     fieldName: 'telephone',
-    type: ['Credential', 'MobileNumberCredential']
+    type: ['Credential'],
+    context: [
+      'https://w3id.org/identity/v1',
+      'https://w3id.org/security/v1',
+      'https://w3id.org/credentials/v1',
+      'http://schema.org'
+    ]
   }
 }
 

--- a/ts/linkedDataSignature/suites/ecdsaKoblitzSignature2016.ts
+++ b/ts/linkedDataSignature/suites/ecdsaKoblitzSignature2016.ts
@@ -2,6 +2,7 @@ import { Type, plainToClass, classToPlain } from 'class-transformer'
 import { canonize } from 'jsonld'
 import { ILinkedDataSignature } from '../types'
 import { sha256 } from '../../utils/crypto'
+import { defaultContext } from '../../utils/contexts';
 
 export class EcdsaLinkedDataSignature implements ILinkedDataSignature {
   public type = 'EcdsaKoblitzSignature2016'
@@ -30,12 +31,12 @@ export class EcdsaLinkedDataSignature implements ILinkedDataSignature {
     return sha256(Buffer.from(normalized)).toString('hex')
   }
 
-  // TODO HAVE A COMMON LARGE NORMALIZATION CONTEXT
   private async normalize(): Promise<string> {
     const json = this.toJSON()
-    json['@context'] = ['https://w3id.org/security/v1']
 
+    json['@context'] = defaultContext
     delete json.signatureValue
+
     return canonize(json)
   }
 }

--- a/ts/utils/contexts.ts
+++ b/ts/utils/contexts.ts
@@ -1,0 +1,25 @@
+export const defaultContext = {
+  id: '@id',
+  type: '@type',
+  cred: 'https://w3id.org/credentials#',
+  schema: 'http://schema.org/',
+  sec: 'https://w3id.org/security#',
+  dc: 'http://purl.org/dc/terms/',
+  xsd: 'http://www.w3.org/2001/XMLSchema#',
+
+  proof: { '@id': 'sec:proof', '@type': '@id' },
+  EcdsaKoblitzSignature2016: 'sec:EcdsaKoblitzSignature2016',
+  created: { '@id': 'dc:created', '@type': 'xsd:dateTime' },
+  creator: { '@id': 'dc:creator', '@type': '@id' },
+  domain: 'sec:domain',
+  nonce: 'sec:nonce',
+  signatureValue: 'sec:signatureValue',
+
+  Credential: 'cred:Credential',
+  issuer: { '@id': 'cred:issuer', '@type': '@id' },
+  issued: { '@id': 'cred:issued', '@type': 'xsd:dateTime' },
+
+  claim: { '@id': 'cred:claim', '@type': '@id' },
+  telephone: 'schema:telephone',
+  email: 'schema:email',
+}


### PR DESCRIPTION
Allows the canonization of the dataset without the need to fetch remote
vocabularies. Changed the name of the signature field to "proof" as per the
specification.

Fixes #54 and #52 