### PR TITLE
Function for retrieving a display name

### DIFF
--- a/ts/credentials/credential/index.ts
+++ b/ts/credentials/credential/index.ts
@@ -12,10 +12,14 @@ export class Credential {
   @Expose()
   private claim: IClaimAttrs
 
+  @Expose()
+  private name: string
+
   public assemble(metadata: IClaimMetadata, value: string, subject: string): Credential {
     const cred = new Credential()
-    cred.type = metadata.type
     cred['@context'] = metadata.context
+    cred.type = metadata.type
+    cred.name = metadata.name
     cred.claim = {
       id: subject,
       [metadata.fieldName]: value
@@ -30,6 +34,10 @@ export class Credential {
 
   public getType(): string[] {
     return this.type
+  }
+
+  public getName(): string {
+    return this.name
   }
 
   public getContext(): string[] | object[] {

--- a/ts/credentials/verifiableCredential/index.ts
+++ b/ts/credentials/verifiableCredential/index.ts
@@ -20,6 +20,9 @@ export class VerifiableCredential {
   private id: string
 
   @Expose()
+  private name: string
+
+  @Expose()
   private issuer: string
 
   @Expose()
@@ -61,11 +64,26 @@ export class VerifiableCredential {
     return this.claim
   }
 
+  public getDisplayName(): string {
+    if (this.name) {
+      return this.name
+    }
+
+    const customType = this.type.find((t) => t !== 'Credential')
+
+    if (!customType) {
+      return 'Credential'
+    }
+
+    return customType.replace(/([A-Z])/g, ' $1').trim()
+  }
+
   public fromCredential(credential: Credential): VerifiableCredential {
     const vc = new VerifiableCredential()
     vc['@context'] = credential.getContext()
     vc.type = credential.getType()
     vc.claim = credential.getClaim()
+    vc.name = credential.getName()
     return vc
   }
 

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -26,6 +26,7 @@ export const claimsMetadata: IDefaultClaimsMetadata = {
   emailAddress: {
     fieldName: 'email',
     type: ['Credential', 'ProofOfEmailCredential'],
+    name: 'Email address',
     context: [
       'https://w3id.org/identity/v1',
       'https://identity.jolocom.com/terms',
@@ -37,6 +38,7 @@ export const claimsMetadata: IDefaultClaimsMetadata = {
   mobilePhoneNumber: {
     fieldName: 'telephone',
     type: ['Credential', 'ProofOfMobilePhoneNumber'],
+    name: 'Mobile Phone Number',
     context: [
       'https://w3id.org/identity/v1',
       'https://identity.jolocom.com/terms',


### PR DESCRIPTION
Addresses #72 

Given that the credential has the `name` field, it will be return, otherwise the name will be derived from the type.


Given the type `['Credential', 'ProofOfAgeCredential']` the `Proof Of Age Credential` name will be returned, namely the first type that is not `Credential`, with white spaces introduced.


If no name and no custom types are available, then `Credential` will be returned.