### PR TITLE
Converting date to ISO format to avoid timezone issues

### DIFF
--- a/ts/credentials/signedCredential/signedCredential.ts
+++ b/ts/credentials/signedCredential/signedCredential.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata'
-import { plainToClass, classToPlain, Type, Exclude, Expose } from 'class-transformer'
+import { Transform, plainToClass, classToPlain, Type, Exclude, Expose } from 'class-transformer'
 import { canonize } from 'jsonld'
 import { Credential } from '../credential/credential'
 import { generateRandomID, sign, sha256, verifySignature, privateKeyToDID } from '../../utils/crypto'
@@ -33,6 +33,8 @@ export class SignedCredential implements IVerifiable {
 
   @Type(() => Date)
   @Expose()
+  @Transform((value: Date) => value.toISOString(), {toPlainOnly: true})
+  @Transform((value: string) => new Date(value), {toClassOnly: true})
   private issued: Date
 
   @Type(() => Date)
@@ -57,6 +59,10 @@ export class SignedCredential implements IVerifiable {
 
   public getId(): string {
     return this.id
+  }
+
+  public getIssued(): Date {
+    return this.issued
   }
 
   public getType(): string[] {

--- a/ts/linkedDataSignature/suites/ecdsaKoblitzSignature2016.ts
+++ b/ts/linkedDataSignature/suites/ecdsaKoblitzSignature2016.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata'
-import { Type, plainToClass, classToPlain, Exclude, Expose } from 'class-transformer'
+import { Type, plainToClass, classToPlain, Exclude, Expose, Transform } from 'class-transformer'
 import { canonize } from 'jsonld'
 import { ILinkedDataSignature, proofTypes, ILinkedDataSignatureAttrs } from '../types'
 import { sha256 } from '../../utils/crypto'
@@ -11,6 +11,8 @@ export class EcdsaLinkedDataSignature implements ILinkedDataSignature {
   public type = 'EcdsaKoblitzSignature2016'
 
   @Type(() => Date)
+  @Transform((value: Date) => value.toISOString(), {toPlainOnly: true})
+  @Transform((value: string) => new Date(value), {toClassOnly: true})
   @Expose()
   public created: Date
 


### PR DESCRIPTION
We need to explicitly convert dates to ISO formats in our code, otherwise things go wrong with `class-transformer` and during the canonicalization process the dates are replaced with local equivalents, which results in different times / hashes, and subsequently different digest.

Solves the issue of credentials signed in one time zone using Jolocom Lib being unverifiable in other time zones.