### PR TITLE
chore(typescript): bumped typescript to 3.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "source-map-support": "^0.5.10",
     "ts-node": "^8.0.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.4.1",
+    "typescript": "^3.6.3",
     "web3": "1.0.0-beta.35"
   },
   "config": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8434,10 +8434,10 @@ typescript@^2.6.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
-typescript@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.1.tgz#b6691be11a881ffa9a05765a205cb7383f3b63c6"
-  integrity sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==
+typescript@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
+  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Built and ran all tests, also regenerated the typing files using `yarn build`. The tests pass and
the output is the same. With this version of TS we get access to type modifiers such as `Omit`