### PR TITLE
Feat/329/jsonld validation

### DIFF
--- a/tests/data/didDocument.data.ts
+++ b/tests/data/didDocument.data.ts
@@ -40,6 +40,7 @@ export const didDocumentJSON = {
 export const normalizedDidDocument =
   '\
 <did:jolo:b2d5d8d6cc140033419b54a237a5db51710439f9f462d1fc98f698eca7ce9777#keys-1> <https://w3id.org/security#owner> <did:jolo:b2d5d8d6cc140033419b54a237a5db51710439f9f462d1fc98f698eca7ce9777> .\n\
+<did:jolo:b2d5d8d6cc140033419b54a237a5db51710439f9f462d1fc98f698eca7ce9777#keys-1> <https://w3id.org/security#publicKeyHex> "03848af62bffceb57631780ac0e0726106ee1c23262d6fd7ef906559d68f53a551" .\n\
 <did:jolo:b2d5d8d6cc140033419b54a237a5db51710439f9f462d1fc98f698eca7ce9777> <http://purl.org/dc/terms/created> "1970-01-01T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n\
 <did:jolo:b2d5d8d6cc140033419b54a237a5db51710439f9f462d1fc98f698eca7ce9777> <https://w3id.org/security#authenticationMethod> _:c14n0 .\n\
 <did:jolo:b2d5d8d6cc140033419b54a237a5db51710439f9f462d1fc98f698eca7ce9777> <https://w3id.org/security#publicKey> <did:jolo:b2d5d8d6cc140033419b54a237a5db51710439f9f462d1fc98f698eca7ce9777#keys-1> .\n\

--- a/tests/identity/didDocument.test.ts
+++ b/tests/identity/didDocument.test.ts
@@ -1,7 +1,6 @@
 import * as chai from 'chai'
 import * as sinon from 'sinon'
 import * as crypto from 'crypto'
-import * as jsonld from 'jsonld'
 import { testPublicIdentityKey } from '../data/keys.data'
 import {
   didDocumentJSON,
@@ -10,7 +9,7 @@ import {
   normalizedDidDocument,
 } from '../data/didDocument.data'
 import { DidDocument } from '../../ts/identity/didDocument/didDocument'
-import { normalizeJsonLd } from '../../ts/utils/validation'
+import { normalizeJsonLd } from '../../ts/linkedData'
 const expect = chai.expect
 
 describe('DidDocument', () => {

--- a/tests/identity/didDocument.test.ts
+++ b/tests/identity/didDocument.test.ts
@@ -10,7 +10,7 @@ import {
   normalizedDidDocument,
 } from '../data/didDocument.data'
 import { DidDocument } from '../../ts/identity/didDocument/didDocument'
-import { IDidDocumentAttrs } from '../../ts/identity/didDocument/types'
+import { normalizeJsonLd } from '../../ts/utils/validation'
 const expect = chai.expect
 
 describe('DidDocument', () => {
@@ -21,7 +21,6 @@ describe('DidDocument', () => {
 
   before(() => {
     clock = sinon.useFakeTimers()
-    sandbox.stub(jsonld, 'canonize').returns(normalizedDidDocument)
     sandbox
       .stub(crypto, 'randomBytes')
       .returns(Buffer.from('1842fb5f567dd532', 'hex'))
@@ -46,12 +45,14 @@ describe('DidDocument', () => {
   })
 
   it('Should correctly implement normalize', async () => {
-    await referenceDidDocument.digest()
+    const {proof, ...document} = referenceDidDocument.toJSON()
 
-    const excludingProof = { ...didDocumentJSON } as IDidDocumentAttrs
-    delete excludingProof.proof
+    const njld = await normalizeJsonLd(
+        document,
+        referenceDidDocument.context
+    )
 
-    sandbox.assert.calledWith(jsonld.canonize, excludingProof)
+    expect(njld).to.deep.eq(normalizedDidDocument)
   })
 
   it('implements getters', () => {

--- a/tests/identity/didDocument.test.ts
+++ b/tests/identity/didDocument.test.ts
@@ -44,13 +44,8 @@ describe('DidDocument', () => {
   })
 
   it('Should correctly implement normalize', async () => {
-    const {proof, ...document} = referenceDidDocument.toJSON()
-
-    const njld = await normalizeJsonLd(
-        document,
-        referenceDidDocument.context
-    )
-
+    const { proof, ...document } = referenceDidDocument.toJSON()
+    const njld = await normalizeJsonLd(document, referenceDidDocument.context)
     expect(njld).to.deep.eq(normalizedDidDocument)
   })
 

--- a/tests/linkedData/index.test.ts
+++ b/tests/linkedData/index.test.ts
@@ -1,0 +1,169 @@
+import * as chai from 'chai'
+import * as sinonChai from 'sinon-chai'
+import { validateJsonLd } from '../../ts/linkedData'
+import { IRegistry } from '../../ts/registries/types'
+import { Identity } from '../../ts/identity/identity'
+import { DidDocument } from '../../ts/identity/didDocument/didDocument'
+
+chai.use(sinonChai)
+const expect = chai.expect
+
+const DID_DOC_V0 = {
+  '@context': [
+    {
+      id: '@id',
+      type: '@type',
+      dc: 'http://purl.org/dc/terms/',
+      rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
+      schema: 'http://schema.org/',
+      sec: 'https://w3id.org/security#',
+      didv: 'https://w3id.org/did#',
+      xsd: 'http://www.w3.org/2001/XMLSchema#',
+      AuthenticationSuite: 'sec:AuthenticationSuite',
+      CryptographicKey: 'sec:Key',
+      LinkedDataSignature2016: 'sec:LinkedDataSignature2016',
+      authentication: 'sec:authenticationMethod',
+      created: { '@id': 'dc:created', '@type': 'xsd:dateTime' },
+      creator: { '@id': 'dc:creator', '@type': '@id' },
+      digestAlgorithm: 'sec:digestAlgorithm',
+      digestValue: 'sec:digestValue',
+      domain: 'sec:domain',
+      entity: 'sec:entity',
+      expires: { '@id': 'sec:expiration', '@type': 'xsd:dateTime' },
+      name: 'schema:name',
+      nonce: 'sec:nonce',
+      normalizationAlgorithm: 'sec:normalizationAlgorithm',
+      owner: { '@id': 'sec:owner', '@type': '@id' },
+      privateKey: { '@id': 'sec:privateKey', '@type': '@id' },
+      proof: 'sec:proof',
+      proofAlgorithm: 'sec:proofAlgorithm',
+      proofType: 'sec:proofType',
+      proofValue: 'sec:proofValue',
+      publicKey: {
+        '@id': 'sec:publicKey',
+        '@type': '@id',
+        '@container': '@set',
+      },
+      publicKeyHex: 'sec:publicKeyHex',
+      requiredProof: 'sec:requiredProof',
+      revoked: { '@id': 'sec:revoked', '@type': 'xsd:dateTime' },
+      signature: 'sec:signature',
+      signatureAlgorithm: 'sec:signatureAlgorithm',
+      signatureValue: 'sec:signatureValue',
+    },
+  ],
+  id:
+    'did:jolo:d74f9e9c9a405e87352211afc9575e6dc8aa99ae8870c1bbcc2adf68084d80f4',
+  authentication: [
+    {
+      publicKey:
+        'did:jolo:d74f9e9c9a405e87352211afc9575e6dc8aa99ae8870c1bbcc2adf68084d80f4#keys-1',
+      type: 'Secp256k1SignatureAuthentication2018',
+    },
+  ],
+  publicKey: [
+    {
+      owner:
+        'did:jolo:d74f9e9c9a405e87352211afc9575e6dc8aa99ae8870c1bbcc2adf68084d80f4',
+      id:
+        'did:jolo:d74f9e9c9a405e87352211afc9575e6dc8aa99ae8870c1bbcc2adf68084d80f4#keys-1',
+      type: 'Secp256k1VerificationKey2018',
+      publicKeyHex:
+        '02c804dd5515c6ea8c22975425f8c5455c547e0c9df9990bcb03661b10e4c68cc8',
+    },
+  ],
+  service: [],
+  created: '2019-08-07T10:20:22.480Z',
+  proof: {
+    created: '2019-08-07T10:20:22.493Z',
+    type: 'EcdsaKoblitzSignature2016',
+    nonce: '4954e82afc9ed2ae',
+    signatureValue:
+      '85049aa73272be60204d4c6ee5f8f6a3a83d2bc8797282fe38f885fb98a208192c9e4a413f7aa2463cf29ff6ae3e85cbb3d1bcf5652fd4f35f01b73f7089477a',
+    creator:
+      'did:jolo:d74f9e9c9a405e87352211afc9575e6dc8aa99ae8870c1bbcc2adf68084d80f4#keys-1',
+  },
+}
+
+const DID_DOC_V0_13 = {
+  specVersion: 0.13,
+  '@context': [
+    'https://www.w3.org/2019/did/v1',
+    'https://w3id.org/did/v0.11',
+    'https://w3id.org/did/v1',
+    { EcdsaKoblitzSignature2016: 'sec:EcdsaKoblitzSignature2016' },
+    {
+      xsd: 'http://www.w3.org/2001/XMLSchema#',
+      sec: 'https://w3id.org/security#',
+      schema: 'http://schema.org/',
+      didv: 'https://w3id.org/did#',
+      publicKeyHex: 'sec:publicKeyHex',
+      updated: { '@id': 'didv:updated', '@type': 'xsd:dateTime' },
+      specVersion: 'schema:version',
+      Secp256k1VerificationKey2018: 'sec:Secp256k1VerificationKey2018',
+      JolocomPublicProfile: 'https://identity.jolocom.com/terms/PublicProfile',
+    },
+  ],
+  id:
+    'did:jolo:1ff29fd63b896ca94b5efe35bd61eba809b5293a1cdf995dfa9cc7a8a8e1c348',
+  authentication: [
+    'did:jolo:1ff29fd63b896ca94b5efe35bd61eba809b5293a1cdf995dfa9cc7a8a8e1c348#keys-1',
+  ],
+  publicKey: [
+    {
+      controller:
+        'did:jolo:1ff29fd63b896ca94b5efe35bd61eba809b5293a1cdf995dfa9cc7a8a8e1c348',
+      id:
+        'did:jolo:1ff29fd63b896ca94b5efe35bd61eba809b5293a1cdf995dfa9cc7a8a8e1c348#keys-1',
+      type: 'Secp256k1VerificationKey2018',
+      publicKeyHex:
+        '031cb4105e392208c78085cb618a2695ee4e732534bc8f6b2f699f116c9607b84d',
+    },
+  ],
+  service: [],
+  created: '2019-08-10T13:56:40.240Z',
+  updated: '2019-08-10T13:56:40.934Z',
+  proof: {
+    created: '2019-08-10T13:56:40.934Z',
+    type: 'EcdsaKoblitzSignature2016',
+    nonce: '730c39662aa79d17',
+    signatureValue:
+      'edcffa601bfbe5ece45c513799e34b5a8d957ce7eb94441efc250f7ba7749d10424a0d7f54ba8837b89f804fed52992cf1ac00d874b5215068876a6345359394',
+    creator:
+      'did:jolo:1ff29fd63b896ca94b5efe35bd61eba809b5293a1cdf995dfa9cc7a8a8e1c348#keys-1',
+  },
+}
+
+describe('linkedData validation functions', () => {
+  it('validateJsonLd should correctly validate', async () => {
+    //@ts-ignore
+    const mockRegistry: IRegistry = {
+      resolve: async did =>
+        Identity.fromDidDocument({
+          didDocument: DidDocument.fromJSON(DID_DOC_V0),
+        }),
+    }
+
+    const mallformedV0 = {
+      ...DID_DOC_V0,
+      proof: {
+        ...DID_DOC_V0.proof,
+        nonce: '0',
+      },
+    }
+
+    const mallformedV013 = {
+      ...DID_DOC_V0_13,
+      proof: {
+        ...DID_DOC_V0_13.proof,
+        nonce: '0',
+      },
+    }
+
+    expect(await validateJsonLd(DID_DOC_V0, mockRegistry)).to.eq(true)
+    // expect(await validateJsonLd(DID_DOC_V0_13, mockRegistry)).to.eq(true)
+
+    expect(await validateJsonLd(mallformedV0, mockRegistry)).to.eq(false)
+    // expect(await validateJsonLd(mallformedV013, mockRegistry)).to.eq(false)
+  })
+})

--- a/tests/linkedData/index.test.ts
+++ b/tests/linkedData/index.test.ts
@@ -85,55 +85,6 @@ const DID_DOC_V0 = {
   },
 }
 
-const DID_DOC_V0_13 = {
-  specVersion: 0.13,
-  '@context': [
-    'https://www.w3.org/2019/did/v1',
-    'https://w3id.org/did/v0.11',
-    'https://w3id.org/did/v1',
-    { EcdsaKoblitzSignature2016: 'sec:EcdsaKoblitzSignature2016' },
-    {
-      xsd: 'http://www.w3.org/2001/XMLSchema#',
-      sec: 'https://w3id.org/security#',
-      schema: 'http://schema.org/',
-      didv: 'https://w3id.org/did#',
-      publicKeyHex: 'sec:publicKeyHex',
-      updated: { '@id': 'didv:updated', '@type': 'xsd:dateTime' },
-      specVersion: 'schema:version',
-      Secp256k1VerificationKey2018: 'sec:Secp256k1VerificationKey2018',
-      JolocomPublicProfile: 'https://identity.jolocom.com/terms/PublicProfile',
-    },
-  ],
-  id:
-    'did:jolo:1ff29fd63b896ca94b5efe35bd61eba809b5293a1cdf995dfa9cc7a8a8e1c348',
-  authentication: [
-    'did:jolo:1ff29fd63b896ca94b5efe35bd61eba809b5293a1cdf995dfa9cc7a8a8e1c348#keys-1',
-  ],
-  publicKey: [
-    {
-      controller:
-        'did:jolo:1ff29fd63b896ca94b5efe35bd61eba809b5293a1cdf995dfa9cc7a8a8e1c348',
-      id:
-        'did:jolo:1ff29fd63b896ca94b5efe35bd61eba809b5293a1cdf995dfa9cc7a8a8e1c348#keys-1',
-      type: 'Secp256k1VerificationKey2018',
-      publicKeyHex:
-        '031cb4105e392208c78085cb618a2695ee4e732534bc8f6b2f699f116c9607b84d',
-    },
-  ],
-  service: [],
-  created: '2019-08-10T13:56:40.240Z',
-  updated: '2019-08-10T13:56:40.934Z',
-  proof: {
-    created: '2019-08-10T13:56:40.934Z',
-    type: 'EcdsaKoblitzSignature2016',
-    nonce: '730c39662aa79d17',
-    signatureValue:
-      'edcffa601bfbe5ece45c513799e34b5a8d957ce7eb94441efc250f7ba7749d10424a0d7f54ba8837b89f804fed52992cf1ac00d874b5215068876a6345359394',
-    creator:
-      'did:jolo:1ff29fd63b896ca94b5efe35bd61eba809b5293a1cdf995dfa9cc7a8a8e1c348#keys-1',
-  },
-}
-
 describe('linkedData validation functions', () => {
   it('validateJsonLd should correctly validate', async () => {
     //@ts-ignore
@@ -152,18 +103,8 @@ describe('linkedData validation functions', () => {
       },
     }
 
-    const mallformedV013 = {
-      ...DID_DOC_V0_13,
-      proof: {
-        ...DID_DOC_V0_13.proof,
-        nonce: '0',
-      },
-    }
-
     expect(await validateJsonLd(DID_DOC_V0, mockRegistry)).to.eq(true)
-    // expect(await validateJsonLd(DID_DOC_V0_13, mockRegistry)).to.eq(true)
 
     expect(await validateJsonLd(mallformedV0, mockRegistry)).to.eq(false)
-    // expect(await validateJsonLd(mallformedV013, mockRegistry)).to.eq(false)
   })
 })

--- a/ts/credentials/credential/credential.ts
+++ b/ts/credentials/credential/credential.ts
@@ -1,8 +1,9 @@
 import { classToPlain, plainToClass, Exclude, Expose } from 'class-transformer'
 import { ICredentialAttrs, IClaimSection } from './types'
-import { BaseMetadata, ContextEntry } from 'cred-types-jolocom-core'
+import { BaseMetadata } from 'cred-types-jolocom-core'
 import { defaultContext } from '../../utils/contexts'
 import { ISignedCredCreationArgs } from '../signedCredential/types'
+import { JsonLdContext } from '../../linkedData/types'
 
 /**
  * @class
@@ -12,7 +13,7 @@ import { ISignedCredCreationArgs } from '../signedCredential/types'
 
 @Exclude()
 export class Credential {
-  private '_@context': ContextEntry[]
+  private '_@context': JsonLdContext
   private _id: string
   private _type: string[]
   private _claim: IClaimSection
@@ -100,7 +101,7 @@ export class Credential {
    */
 
   @Expose({ name: '@context' })
-  public get context(): ContextEntry[] {
+  public get context(): JsonLdContext {
     return this['_@context']
   }
 
@@ -110,7 +111,7 @@ export class Credential {
    * @example `credential.context = [{name: 'http://schema.org/name', ...}, {...}]`
    */
 
-  public set context(context: ContextEntry[]) {
+  public set context(context: JsonLdContext) {
     this['_@context'] = context
   }
 

--- a/ts/credentials/credential/types.ts
+++ b/ts/credentials/credential/types.ts
@@ -1,4 +1,5 @@
-import { ContextEntry, ClaimInterface } from 'cred-types-jolocom-core'
+import { ClaimInterface } from 'cred-types-jolocom-core'
+import { JsonLdObject } from '../../linkedData/types'
 
 type ClaimType = string | number | boolean | {}
 /**
@@ -23,8 +24,7 @@ export interface IClaimSection {
   [x: string]: ClaimEntry
 }
 
-export interface ICredentialAttrs {
-  '@context': ContextEntry[]
+export interface ICredentialAttrs extends JsonLdObject {
   type: string[]
   name?: string
   claim: ClaimEntry

--- a/ts/credentials/signedCredential/signedCredential.ts
+++ b/ts/credentials/signedCredential/signedCredential.ts
@@ -7,8 +7,7 @@ import {
   Transform,
   Type,
 } from 'class-transformer'
-import { canonize } from 'jsonld'
-import { sha256 } from '../../utils/crypto'
+import { digestJsonLd } from '../../utils/validation'
 import { ISignedCredCreationArgs, ISignedCredentialAttrs } from './types'
 import {
   IDigestable,
@@ -350,25 +349,7 @@ export class SignedCredential implements IDigestable {
    */
 
   public async digest(): Promise<Buffer> {
-    const normalized = await this.normalize()
-
-    const docSectionDigest = sha256(Buffer.from(normalized))
-    const proofSectionDigest = await this.proof.digest()
-
-    return sha256(Buffer.concat([proofSectionDigest, docSectionDigest]))
-  }
-
-  /**
-   * Converts the verifiable credential to canonical form
-   * @see {@link https://w3c-dvcg.github.io/ld-signatures/#dfn-canonicalization-algorithm | Canonicalization algorithm }
-   * @internal
-   */
-
-  private async normalize(): Promise<string> {
-    const json = this.toJSON()
-    delete json.proof
-
-    return canonize(json)
+    return digestJsonLd(this.toJSON())
   }
 
   /**

--- a/ts/credentials/signedCredential/signedCredential.ts
+++ b/ts/credentials/signedCredential/signedCredential.ts
@@ -21,9 +21,17 @@ import { ISigner } from '../../registries/types'
 import { Credential } from '../credential/credential'
 import { SoftwareKeyProvider } from '../../vaultedKeyProvider/softwareProvider'
 
-
 // Credentials are valid for a year by default
 const DEFAULT_EXPIRY_MS = 365 * 24 * 3600 * 1000
+
+/**
+ * @ignore
+ * Helper function generating a random claim id
+ * @param length - The length of the random part of the identifier
+ */
+
+const generateClaimId = (length: number): string =>
+  `claimId:${SoftwareKeyProvider.getRandom(length).toString('hex')}`
 
 /**
  * @description Data needed to prepare signature on credential
@@ -372,12 +380,3 @@ export class SignedCredential implements IDigestable {
     return classToPlain(this) as ISignedCredentialAttrs
   }
 }
-
-/**
- * @ignore
- * Helper function generating a random claim id
- * @param length - The length of the random part of the identifier
- */
-
-const generateClaimId = (length: number): string =>
-  `claimId:${SoftwareKeyProvider.getRandom(length).toString('hex')}`

--- a/ts/credentials/signedCredential/signedCredential.ts
+++ b/ts/credentials/signedCredential/signedCredential.ts
@@ -13,9 +13,10 @@ import {
   IDigestable,
   ILinkedDataSignature,
 } from '../../linkedDataSignature/types'
-import { BaseMetadata, ContextEntry } from 'cred-types-jolocom-core'
+import { BaseMetadata } from 'cred-types-jolocom-core'
 import { IClaimSection } from '../credential/types'
 import { EcdsaLinkedDataSignature } from '../../linkedDataSignature'
+import { JsonLdContext } from '../../linkedData/types'
 import { ISigner } from '../../registries/types'
 import { Credential } from '../credential/credential'
 import { SoftwareKeyProvider } from '../../vaultedKeyProvider/softwareProvider'
@@ -42,7 +43,7 @@ interface IIssInfo {
 
 @Exclude()
 export class SignedCredential implements IDigestable {
-  private '_@context': ContextEntry[]
+  private '_@context': JsonLdContext
   private _id: string = generateClaimId(8)
   private _name: string
   private _issuer: string
@@ -69,7 +70,7 @@ export class SignedCredential implements IDigestable {
    * @example `signedCredential.context = [{name: 'http://schema.org/name', ...}, {...}]`
    */
 
-  set context(context: ContextEntry[]) {
+  set context(context: JsonLdContext) {
     this['_@context'] = context
   }
 
@@ -315,7 +316,7 @@ export class SignedCredential implements IDigestable {
     expires = new Date(Date.now() + DEFAULT_EXPIRY_MS),
   ) {
     const credential = Credential.create(credentialOptions)
-    const json = credential.toJSON() as ISignedCredentialAttrs
+    const json = (credential.toJSON() as unknown) as ISignedCredentialAttrs
     const signedCredential = SignedCredential.fromJSON(json)
 
     signedCredential.expires = expires
@@ -349,7 +350,7 @@ export class SignedCredential implements IDigestable {
    */
 
   public async digest(): Promise<Buffer> {
-    return digestJsonLd(this.toJSON())
+    return digestJsonLd(this.toJSON(), this.context)
   }
 
   /**

--- a/ts/credentials/signedCredential/signedCredential.ts
+++ b/ts/credentials/signedCredential/signedCredential.ts
@@ -7,7 +7,7 @@ import {
   Transform,
   Type,
 } from 'class-transformer'
-import { digestJsonLd } from '../../utils/validation'
+import { digestJsonLd } from '../../linkedData'
 import { ISignedCredCreationArgs, ISignedCredentialAttrs } from './types'
 import {
   IDigestable,

--- a/ts/credentials/signedCredential/types.ts
+++ b/ts/credentials/signedCredential/types.ts
@@ -2,7 +2,7 @@ import { ICredentialAttrs, IClaimSection } from '../credential/types'
 import { BaseMetadata } from 'cred-types-jolocom-core'
 import { SignedJsonLdObject } from '../../linkedData/types'
 
-export interface ISignedCredentialAttrs extends Omit<ICredentialAttrs, '@context'>, SignedJsonLdObject {
+export interface ISignedCredentialAttrs extends SignedJsonLdObject, ICredentialAttrs {
   id: string
   issuer: string
   issued: string

--- a/ts/credentials/signedCredential/types.ts
+++ b/ts/credentials/signedCredential/types.ts
@@ -1,14 +1,13 @@
 import { ICredentialAttrs, IClaimSection } from '../credential/types'
-import { ILinkedDataSignatureAttrs } from '../../linkedDataSignature/types'
 import { BaseMetadata } from 'cred-types-jolocom-core'
+import { SignedJsonLdObject } from '../../linkedData/types'
 
-export interface ISignedCredentialAttrs extends ICredentialAttrs {
+export interface ISignedCredentialAttrs extends Omit<ICredentialAttrs, '@context'>, SignedJsonLdObject {
   id: string
   issuer: string
   issued: string
   expires?: string
   claim: IClaimSection
-  proof: ILinkedDataSignatureAttrs
 }
 
 /* Allows for neat claim autocompletion based on metadata type */

--- a/ts/identity/didDocument/didDocument.ts
+++ b/ts/identity/didDocument/didDocument.ts
@@ -14,7 +14,7 @@ import {
   ServiceEndpointsSection,
 } from './sections'
 import { ISigner } from '../../registries/types'
-import { ContextEntry } from 'cred-types-jolocom-core'
+import { JsonLdContext } from '../../linkedData/types'
 import { defaultContextIdentity } from '../../utils/contexts'
 import { publicKeyToDID } from '../../utils/crypto'
 import { digestJsonLd } from '../../linkedData'
@@ -37,7 +37,7 @@ export class DidDocument implements IDigestable {
   private _service: ServiceEndpointsSection[] = []
   private _created: Date = new Date()
   private _proof: ILinkedDataSignature
-  private '_@context': ContextEntry[] = defaultContextIdentity
+  private '_@context': JsonLdContext = defaultContextIdentity
 
   /**
    * Get the `@context` section of the JSON-ld document
@@ -46,7 +46,7 @@ export class DidDocument implements IDigestable {
    */
 
   @Expose({ name: '@context' })
-  get context(): ContextEntry[] {
+  get context(): JsonLdContext {
     return this['_@context']
   }
 
@@ -56,7 +56,7 @@ export class DidDocument implements IDigestable {
    * @example `didDocument.context = [{name: 'http://schema.org/name', ...}, {...}]`
    */
 
-  set context(context: ContextEntry[]) {
+  set context(context: JsonLdContext) {
     this['_@context'] = context
   }
 
@@ -297,7 +297,7 @@ export class DidDocument implements IDigestable {
    */
 
   public async digest(): Promise<Buffer> {
-      return digestJsonLd(this.toJSON())
+      return digestJsonLd(this.toJSON(), this.context)
   }
 
   /**

--- a/ts/identity/didDocument/didDocument.ts
+++ b/ts/identity/didDocument/didDocument.ts
@@ -17,7 +17,7 @@ import { ISigner } from '../../registries/types'
 import { ContextEntry } from 'cred-types-jolocom-core'
 import { defaultContextIdentity } from '../../utils/contexts'
 import { publicKeyToDID } from '../../utils/crypto'
-import { digestJsonLd } from '../../utils/validation'
+import { digestJsonLd } from '../../linkedData'
 import {
   ILinkedDataSignature,
   IDigestable,

--- a/ts/identity/didDocument/didDocument.ts
+++ b/ts/identity/didDocument/didDocument.ts
@@ -7,7 +7,6 @@ import {
   Transform,
 } from 'class-transformer'
 import { IDidDocumentAttrs } from './types'
-import { canonize } from 'jsonld'
 import { EcdsaLinkedDataSignature } from '../../linkedDataSignature'
 import {
   AuthenticationSection,
@@ -17,7 +16,8 @@ import {
 import { ISigner } from '../../registries/types'
 import { ContextEntry } from 'cred-types-jolocom-core'
 import { defaultContextIdentity } from '../../utils/contexts'
-import { sha256, publicKeyToDID } from '../../utils/crypto'
+import { publicKeyToDID } from '../../utils/crypto'
+import { digestJsonLd } from '../../utils/validation'
 import {
   ILinkedDataSignature,
   IDigestable,
@@ -297,24 +297,7 @@ export class DidDocument implements IDigestable {
    */
 
   public async digest(): Promise<Buffer> {
-    const normalized = await this.normalize()
-
-    const docSectionDigest = sha256(Buffer.from(normalized))
-    const proofSectionDigest = await this.proof.digest()
-
-    return sha256(Buffer.concat([proofSectionDigest, docSectionDigest]))
-  }
-
-  /**
-   * Converts the did document to canonical form
-   * @see {@link https://w3c-dvcg.github.io/ld-signatures/#dfn-canonicalization-algorithm | Canonicalization algorithm }
-   * @internal
-   */
-
-  public async normalize(): Promise<string> {
-    const json = this.toJSON()
-    delete json.proof
-    return canonize(json)
+      return digestJsonLd(this.toJSON())
   }
 
   /**

--- a/ts/identity/didDocument/sections/types.ts
+++ b/ts/identity/didDocument/sections/types.ts
@@ -1,15 +1,17 @@
-export interface IPublicKeySectionAttrs {
+import { JsonLdObject } from '../../../linkedData/types'
+
+export interface IPublicKeySectionAttrs extends JsonLdObject {
   id: string
   type: string
   publicKeyHex: string
 }
 
-export interface IAuthenticationSectionAttrs {
+export interface IAuthenticationSectionAttrs extends JsonLdObject {
   publicKey: string
   type: string
 }
 
-export interface IServiceEndpointSectionAttrs {
+export interface IServiceEndpointSectionAttrs extends JsonLdObject {
   id: string
   type: string
   serviceEndpoint: string

--- a/ts/identity/didDocument/types.ts
+++ b/ts/identity/didDocument/types.ts
@@ -3,15 +3,12 @@ import {
   IAuthenticationSectionAttrs,
   IServiceEndpointSectionAttrs,
 } from './sections/types'
-import { ILinkedDataSignatureAttrs } from '../../linkedDataSignature/types'
-import { ContextEntry } from 'cred-types-jolocom-core'
+import { SignedJsonLdObject } from '../../linkedData/types'
 
-export interface IDidDocumentAttrs {
-  '@context': ContextEntry[]
+export interface IDidDocumentAttrs extends SignedJsonLdObject {
   id: string
   authentication: IAuthenticationSectionAttrs[]
   publicKey: IPublicKeySectionAttrs[]
   service: IServiceEndpointSectionAttrs[]
   created: string
-  proof: ILinkedDataSignatureAttrs
 }

--- a/ts/linkedData/index.ts
+++ b/ts/linkedData/index.ts
@@ -1,18 +1,11 @@
 import { SoftwareKeyProvider } from '../vaultedKeyProvider/softwareProvider'
 import { ILinkedDataSignatureAttrs } from '../linkedDataSignature/types'
-import {
-  getIssuerPublicKey,
-  keyIdToDid
-} from '../utils/helper'
+import { getIssuerPublicKey, keyIdToDid } from '../utils/helper'
 import { IRegistry } from '../registries/types'
-import { registries } from '../registries/index'
+import { registries } from '../registries/'
 import { sha256 } from '../utils/crypto'
 import { canonize } from 'jsonld'
-import {
-  JsonLdObject,
-  SignedJsonLdObject,
-  JsonLdContext,
-} from './types'
+import { JsonLdObject, SignedJsonLdObject, JsonLdContext } from './types'
 
 /**
  * Helper function to handle JsonLD normalization.
@@ -25,14 +18,15 @@ import {
 export const normalizeJsonLd = async (
   { ['@context']: _, ...data }: JsonLdObject,
   context: JsonLdContext,
-) => canonize(data, {
-  expandContext: context,
-})
+) =>
+  canonize(data, {
+    expandContext: context,
+  })
 
 /**
  * Helper function to handle JsonLD proof section normalization.
  * @dev The function expects the JsonLD '@context' to be passed as an argument
- * @param data - {@link ILinkedDataSignatures} Proof to be normalised
+ * @param data - {@link ILinkedDataSignatureAttrs} Proof to be normalised
  * @param context - JsonLD context to use during normalization
  */
 
@@ -52,19 +46,19 @@ export const normalizeLdProof = async (
 export const digestJsonLd = async (
   { proof, ['@context']: _, ...data }: SignedJsonLdObject,
   context: JsonLdContext,
-): Promise<Buffer> => sha256(
-  Buffer.concat([
-    sha256(Buffer.from(await normalizeLdProof(proof, context))),
-    sha256(Buffer.from(await normalizeJsonLd(data, context))),
-  ]),
-)
+): Promise<Buffer> =>
+  sha256(
+    Buffer.concat([
+      sha256(Buffer.from(await normalizeLdProof(proof, context))),
+      sha256(Buffer.from(await normalizeJsonLd(data, context))),
+    ]),
+  )
 
 /**
- * Helper function to handle JsonLD normalization.
- * @dev The function expects the JsonLD '@context' to be passed as an argument,
- *  the '@context' on the data will be discarded.
- * @param data - {@link JsonLdObject} without the '@context' section
- * @param context - JsonLD context to use during normalization
+ * Helper function to handle JsonLD validation.
+ * @param json - {@link SignedJsonLdObject} to be validated
+ * @param customRegistry - Custom registry implementation.
+ *   If null, the {@link JolocomRegistry} is used
  */
 
 export const validateJsonLd = async (

--- a/ts/linkedData/index.ts
+++ b/ts/linkedData/index.ts
@@ -1,0 +1,63 @@
+import { SoftwareKeyProvider } from '../vaultedKeyProvider/softwareProvider'
+import { ILinkedDataSignatureAttrs } from '../linkedDataSignature/types'
+import { getIssuerPublicKey } from './helper'
+import { IRegistry } from '../registries/types'
+import { registries } from '../registries/index'
+import { sha256 } from '../utils/crypto'
+import { canonize } from 'jsonld'
+
+/**
+ * Helper function to handle JsonLD normalization.
+ * @dev The function expects the JsonLD '@context' to be passed as an argument,
+ *  the '@context' on the data will be discarded.
+ * @param data - {@link JsonLdObject} without the '@context' section
+ * @param context - JsonLD context to use during normalization
+ */
+
+export const normalizeJsonLd = async ({ ['@context']: _, ...data }, context) => {
+  return canonize(data, {
+    expandContext: context,
+  })
+}
+
+export const normalizeLdProof = async (
+  //@ts-ignore
+  proof: ILinkedDataSignatureAttrs,
+  context,
+): Promise<string> => {
+  const { signatureValue, id, type, ...toNormalize } = proof
+  //@ts-ignore
+  return normalizeJsonLd(toNormalize, context)
+}
+
+export const digestJsonLd = async (
+    {proof, ...data},
+): Promise<Buffer> => sha256(Buffer.concat([
+    sha256(Buffer.from(await normalizeLdProof(proof, data['@context']))),
+    //@ts-ignore
+    sha256(Buffer.from(await normalizeJsonLd(data, data['@context'])))
+]))
+
+
+export const validateJsonLd = async (
+    json,
+    customRegistry?: IRegistry
+): Promise<boolean> => {
+    const reg = customRegistry || registries.jolocom.create()
+    console.log(json)
+    try {
+        const issuerIdentity = await reg.resolve(json.proof.creator)
+        const issuerPublicKey = getIssuerPublicKey(
+            json.proof.id,
+            issuerIdentity.didDocument,
+        )
+        return SoftwareKeyProvider.verify(
+            await digestJsonLd(json),
+            issuerPublicKey,
+            Buffer.from(json.proof.signatureValue, 'hex')
+        )
+    } catch {
+        return false
+    }
+
+}

--- a/ts/linkedData/index.ts
+++ b/ts/linkedData/index.ts
@@ -11,6 +11,7 @@ import { JsonLdObject, SignedJsonLdObject, JsonLdContext } from './types'
  * Helper function to handle JsonLD normalization.
  * @dev The function expects the JsonLD '@context' to be passed as an argument,
  *  the '@context' on the data will be discarded.
+ * @internal
  * @param data - {@link JsonLdObject} without the '@context' section
  * @param context - JsonLD context to use during normalization
  */
@@ -26,6 +27,7 @@ export const normalizeJsonLd = async (
 /**
  * Helper function to handle JsonLD proof section normalization.
  * @dev The function expects the JsonLD '@context' to be passed as an argument
+ * @internal
  * @param data - {@link ILinkedDataSignatureAttrs} Proof to be normalised
  * @param context - JsonLD context to use during normalization
  */
@@ -39,6 +41,7 @@ export const normalizeLdProof = async (
  * Helper function to handle signed JsonLD digestions
  * @dev The function expects the JsonLD '@context' to be passed as an argument,
  *  the '@context' on the data will be discarded.
+ * @internal
  * @param data - {@link SignedJsonLdObject}
  * @param context - JsonLD context to use during normalization
  */
@@ -66,8 +69,9 @@ export const validateJsonLd = async (
   customRegistry?: IRegistry,
 ): Promise<boolean> => {
   const reg = customRegistry || registries.jolocom.create()
+  const issuerIdentity = await reg.resolve(keyIdToDid(json.proof.creator))
+
   try {
-    const issuerIdentity = await reg.resolve(keyIdToDid(json.proof.creator))
     const issuerPublicKey = getIssuerPublicKey(
       json.proof.creator,
       issuerIdentity.didDocument,

--- a/ts/linkedData/index.ts
+++ b/ts/linkedData/index.ts
@@ -50,7 +50,7 @@ export const normalizeLdProof = async (
  */
 
 export const digestJsonLd = async (
-  { proof, ['@context']: _, ...body }: SignedJsonLdObject,
+  { proof, ['@context']: _, ...data }: SignedJsonLdObject,
   context: JsonLdContext,
 ): Promise<Buffer> => sha256(
   Buffer.concat([
@@ -79,7 +79,7 @@ export const validateJsonLd = async (
       issuerIdentity.didDocument,
     )
     return SoftwareKeyProvider.verify(
-      await digestJsonLd(json),
+      await digestJsonLd(json, json['@context']),
       issuerPublicKey,
       Buffer.from(json.proof.signatureValue, 'hex'),
     )

--- a/ts/linkedData/types.ts
+++ b/ts/linkedData/types.ts
@@ -3,9 +3,7 @@ import { ContextEntry } from 'cred-types-jolocom-core'
 
 type JsonLdPrimitive = string | number | boolean | JsonLdObject | JsonLdObject[]
 
-export type JsonLdContextEntry = ContextEntry
-
-export type JsonLdContext = JsonLdContextEntry | JsonLdContextEntry[]
+export type JsonLdContext = ContextEntry | ContextEntry[]
 
 export interface JsonLdObject {
   '@context'?: JsonLdContext

--- a/ts/linkedData/types.ts
+++ b/ts/linkedData/types.ts
@@ -1,4 +1,4 @@
-
+import { ILinkedDataSignatureAttrs } from '../linkedDataSignature/types'
 
 type JsonLdPrimitive = string | number | boolean | JsonLdObject | JsonLdObject[]
 

--- a/ts/linkedData/types.ts
+++ b/ts/linkedData/types.ts
@@ -12,6 +12,5 @@ export interface JsonLdObject {
 }
 
 export interface SignedJsonLdObject extends JsonLdObject {
-  '@context': JsonLdContext
   proof: ILinkedDataSignatureAttrs
 }

--- a/ts/linkedData/types.ts
+++ b/ts/linkedData/types.ts
@@ -1,8 +1,9 @@
 import { ILinkedDataSignatureAttrs } from '../linkedDataSignature/types'
+import { ContextEntry } from 'cred-types-jolocom-core'
 
 type JsonLdPrimitive = string | number | boolean | JsonLdObject | JsonLdObject[]
 
-export type JsonLdContextEntry = string | JsonLdObject
+export type JsonLdContextEntry = ContextEntry
 
 export type JsonLdContext = JsonLdContextEntry | JsonLdContextEntry[]
 

--- a/ts/linkedData/types.ts
+++ b/ts/linkedData/types.ts
@@ -1,0 +1,17 @@
+
+
+type JsonLdPrimitive = string | number | boolean | JsonLdObject | JsonLdObject[]
+
+export type JsonLdContextEntry = string | JsonLdObject
+
+export type JsonLdContext = JsonLdContextEntry | JsonLdContextEntry[]
+
+export interface JsonLdObject {
+  '@context'?: JsonLdContext
+  [key: string]: JsonLdPrimitive | JsonLdPrimitive[]
+}
+
+export interface SignedJsonLdObject extends JsonLdObject {
+  '@context': JsonLdContext
+  proof: ILinkedDataSignatureAttrs
+}

--- a/ts/linkedDataSignature/types.ts
+++ b/ts/linkedDataSignature/types.ts
@@ -1,3 +1,5 @@
+import { JsonLdObject } from '../linkedData/types'
+
 export interface ISerializable {
   toJSON: () => {}
 }
@@ -17,7 +19,7 @@ export interface IDigestable {
   }
 }
 
-export interface ILinkedDataSignatureAttrs {
+export interface ILinkedDataSignatureAttrs extends JsonLdObject {
   type: string
   created: string
   creator: string

--- a/ts/utils/contexts.ts
+++ b/ts/utils/contexts.ts
@@ -1,8 +1,6 @@
-import { JsonLdContextEntry } from '../linkedData/types'
-
 /* Expanded default context for verifiable credentials, more verbose, but works in offline use cases */
 
-export const defaultContext: JsonLdContextEntry[] = [
+export const defaultContext = [
   {
     id: '@id',
     type: '@type',
@@ -29,7 +27,7 @@ export const defaultContext: JsonLdContextEntry[] = [
 
 /* Expanded default context for did documents, more verbose, but works in offline use cases */
 
-export const defaultContextIdentity: JsonLdContextEntry[] = [
+export const defaultContextIdentity = [
   {
     id: '@id',
     type: '@type',

--- a/ts/utils/contexts.ts
+++ b/ts/utils/contexts.ts
@@ -1,8 +1,8 @@
-import { ContextEntry } from 'cred-types-jolocom-core'
+import { JsonLdContextEntry } from '../linkedData/types'
 
 /* Expanded default context for verifiable credentials, more verbose, but works in offline use cases */
 
-export const defaultContext: ContextEntry[] = [
+export const defaultContext: JsonLdContextEntry[] = [
   {
     id: '@id',
     type: '@type',
@@ -29,7 +29,7 @@ export const defaultContext: ContextEntry[] = [
 
 /* Expanded default context for did documents, more verbose, but works in offline use cases */
 
-export const defaultContextIdentity: ContextEntry[] = [
+export const defaultContextIdentity: JsonLdContextEntry[] = [
   {
     id: '@id',
     type: '@type',

--- a/ts/utils/validation.ts
+++ b/ts/utils/validation.ts
@@ -1,7 +1,8 @@
-import { JolocomLib } from '../index'
+import { SoftwareKeyProvider } from '../vaultedKeyProvider/softwareProvider'
 import { IDigestable, ILinkedDataSignatureAttrs } from '../linkedDataSignature/types'
 import { getIssuerPublicKey } from './helper'
 import { IRegistry } from '../registries/types'
+import { registries } from '../registries/index'
 import { sha256 } from '../utils/crypto'
 import { canonize } from 'jsonld'
 
@@ -18,14 +19,14 @@ export const validateDigestable = async (
   toValidate: IDigestable,
   customRegistry?: IRegistry,
 ): Promise<boolean> => {
-  const reg = customRegistry || JolocomLib.registries.jolocom.create()
+  const reg = customRegistry || registries.jolocom.create()
   const issuerIdentity = await reg.resolve(toValidate.signer.did)
   try {
     const issuerPublicKey = getIssuerPublicKey(
       toValidate.signer.keyId,
       issuerIdentity.didDocument,
     )
-    return JolocomLib.KeyProvider.verifyDigestable(issuerPublicKey, toValidate)
+    return SoftwareKeyProvider.verifyDigestable(issuerPublicKey, toValidate)
   } catch {
     return false
   }

--- a/ts/utils/validation.ts
+++ b/ts/utils/validation.ts
@@ -57,26 +57,24 @@ export const validateDigestables = async (
  * @dev The function expects the JsonLD '@context' to be passed as an argument,
  *  the '@context' on the data will be discarded.
  * @param data - {@link JsonLdObject} without the '@context' section
- * @param contextTransformer - {@link ContextTransformer} function for custom context
- *  modifications before it's used for normalization
  * @param context - JsonLD context to use during normalization
  */
 
 
-const normalizeJsonLD = async ({ ['@context']: _, ...data }, context) => {
+export const normalizeJsonLd = async ({ ['@context']: _, ...data }, context) => {
   return canonize(data, {
     expandContext: context,
   })
 }
 
-const normalizeLdProof = async (
+export const normalizeLdProof = async (
   //@ts-ignore
   proof: ILinkedDataSignatureAttrs,
   context,
 ): Promise<string> => {
   const { signatureValue, id, type, ...toNormalize } = proof
   //@ts-ignore
-  return normalizeJsonLD(toNormalize, context)
+  return normalizeJsonLd(toNormalize, context)
 }
 
 export const digestJsonLd = async (
@@ -84,5 +82,5 @@ export const digestJsonLd = async (
 ): Promise<Buffer> => sha256(Buffer.concat([
     sha256(Buffer.from(await normalizeLdProof(proof, data['@context']))),
     //@ts-ignore
-    sha256(Buffer.from(await normalizeJsonLD(data, data['@context'])))
+    sha256(Buffer.from(await normalizeJsonLd(data, data['@context'])))
 ]))

--- a/ts/utils/validation.ts
+++ b/ts/utils/validation.ts
@@ -62,25 +62,20 @@ export const validateDigestables = async (
  */
 
 
-const normalizeJsonLD = async (
-  { ['@context']: _, ...data },//: JsonLdObject,
-  context,
-  // contextTransformer: ContextTransformer = cachedContextTransformer,
-) => {
+const normalizeJsonLD = async ({ ['@context']: _, ...data }, context) => {
   return canonize(data, {
-    expandContext: context, //contextTransformer(context),
+    expandContext: context,
   })
 }
 
-const normalizeLdProof = (
+const normalizeLdProof = async (
   //@ts-ignore
-  { ['@context']: _, ...proof }: ILinkedDataSignatureAttrs,
+  proof: ILinkedDataSignatureAttrs,
   context,
-  // contextTransformer: ContextTransformer = cachedContextTransformer,
 ): Promise<string> => {
   const { signatureValue, id, type, ...toNormalize } = proof
   //@ts-ignore
-  return normalizeJsonLD(toNormalize, context)//, contextTransformer)
+  return normalizeJsonLD(toNormalize, context)
 }
 
 export const digestJsonLd = async (

--- a/ts/utils/validation.ts
+++ b/ts/utils/validation.ts
@@ -1,10 +1,8 @@
 import { SoftwareKeyProvider } from '../vaultedKeyProvider/softwareProvider'
-import { IDigestable, ILinkedDataSignatureAttrs } from '../linkedDataSignature/types'
+import { IDigestable } from '../linkedDataSignature/types'
 import { getIssuerPublicKey } from './helper'
 import { IRegistry } from '../registries/types'
 import { registries } from '../registries/index'
-import { sha256 } from '../utils/crypto'
-import { canonize } from 'jsonld'
 
 /**
  * Validates the signature on a {@link SignedCredential} or {@link JSONWebToken}
@@ -51,36 +49,3 @@ export const validateDigestables = async (
     ),
   )
 
-
-/**
- * Helper function to handle JsonLD normalization.
- * @dev The function expects the JsonLD '@context' to be passed as an argument,
- *  the '@context' on the data will be discarded.
- * @param data - {@link JsonLdObject} without the '@context' section
- * @param context - JsonLD context to use during normalization
- */
-
-
-export const normalizeJsonLd = async ({ ['@context']: _, ...data }, context) => {
-  return canonize(data, {
-    expandContext: context,
-  })
-}
-
-export const normalizeLdProof = async (
-  //@ts-ignore
-  proof: ILinkedDataSignatureAttrs,
-  context,
-): Promise<string> => {
-  const { signatureValue, id, type, ...toNormalize } = proof
-  //@ts-ignore
-  return normalizeJsonLd(toNormalize, context)
-}
-
-export const digestJsonLd = async (
-    {proof, ...data},
-): Promise<Buffer> => sha256(Buffer.concat([
-    sha256(Buffer.from(await normalizeLdProof(proof, data['@context']))),
-    //@ts-ignore
-    sha256(Buffer.from(await normalizeJsonLd(data, data['@context'])))
-]))


### PR DESCRIPTION
key files are `ts/linkedData/index.ts` and `ts/linkedData/types.ts`. Other changes are including jsonLD types in DID doc sections and credential types, and using the digestion/validation functions in DID doc and signed credential classes.