### PR TITLE
397/issuance aud

### DIFF
--- a/js/errors/index.d.ts
+++ b/js/errors/index.d.ts
@@ -16,6 +16,7 @@ export declare enum ErrorCodes {
     IDWInvalidCreationArgs = "IDWInvalidCreationArgs",
     IDWInvalidJWTSignature = "IDWInvalidJWTSignature",
     IDWNotIntendedAudience = "IDWNotIntendedAudience",
+    IDWNotCorrectResponder = "IDWNotCorrectResponder",
     IDWIncorrectJWTNonce = "IDWIncorrectJWTNonce",
     IDWTokenExpired = "IDWTokenExpired",
     VCInvalidExpiryDate = "VCInvalidExpiryDate"

--- a/js/identityWallet/identityWallet.d.ts
+++ b/js/identityWallet/identityWallet.d.ts
@@ -22,6 +22,7 @@ declare type PublicKeyMap = {
 };
 declare type WithExtraOptions<T> = T & {
     expires?: Date;
+    aud?: string;
 };
 export declare class IdentityWallet {
     private _identity;

--- a/ts/errors/index.ts
+++ b/ts/errors/index.ts
@@ -16,6 +16,7 @@ export enum ErrorCodes {
   IDWInvalidCreationArgs = 'IDWInvalidCreationArgs',
   IDWInvalidJWTSignature = 'IDWInvalidJWTSignature',
   IDWNotIntendedAudience = 'IDWNotIntendedAudience',
+  IDWNotCorrectResponder = 'IDWNotCorrectResponder',
   IDWIncorrectJWTNonce = 'IDWIncorrectJWTNonce',
   IDWTokenExpired = 'IDWTokenExpired',
   VCInvalidExpiryDate = 'VCInvalidExpiryDate',

--- a/ts/identityWallet/identityWallet.ts
+++ b/ts/identityWallet/identityWallet.ts
@@ -75,6 +75,7 @@ type PublicKeyMap = { [key in keyof typeof KeyTypes]?: string }
 
 type WithExtraOptions<T> = T & {
   expires?: Date
+  aud?: string
 }
 
 /**
@@ -273,6 +274,8 @@ export class IdentityWallet {
     jwt.interactionType = InteractionType.Authentication
     jwt.timestampAndSetExpiry(authArgs.expires)
 
+    if (!recievedJWT && authArgs.aud) jwt.audience = authArgs.aud
+
     return this.initializeAndSign(
       jwt,
       this.publicKeyMetadata.derivationPath,
@@ -295,6 +298,8 @@ export class IdentityWallet {
     const jwt = JSONWebToken.fromJWTEncodable(offer)
     jwt.interactionType = InteractionType.CredentialOfferRequest
     jwt.timestampAndSetExpiry(credOffer.expires)
+
+    if (credOffer.aud) jwt.audience = credOffer.aud
 
     return this.initializeAndSign(
       jwt,
@@ -346,6 +351,9 @@ export class IdentityWallet {
     const jwt = JSONWebToken.fromJWTEncodable(credentialRequest)
     jwt.interactionType = InteractionType.CredentialRequest
     jwt.timestampAndSetExpiry(credReq.expires)
+
+    if (credReq.aud) jwt.audience = credReq.aud
+
     return this.initializeAndSign(
       jwt,
       this.publicKeyMetadata.derivationPath,

--- a/ts/identityWallet/identityWallet.ts
+++ b/ts/identityWallet/identityWallet.ts
@@ -344,7 +344,7 @@ export class IdentityWallet {
   }
 
   /**
-   * Validates interaction tokens for signature - if only received token passed - and for audience (aud) and token nonce (jti) if send token passed also
+   * Validates interaction tokens for signatures, expiry, jti, and audience
    * @param receivedJWT - received JSONWebToken Class
    * @param sendJWT - optional send JSONWebToken Class which is used to validate the token nonce and the aud field on received token
    * @param customRegistry - optional custom registry
@@ -352,40 +352,47 @@ export class IdentityWallet {
 
   public async validateJWT<T, R>(
     receivedJWT: JSONWebToken<T>,
-    sendJWT?: JSONWebToken<R>,
+    sentJWT?: JSONWebToken<R>,
     customRegistry?: IRegistry,
   ): Promise<void> {
     const registry = customRegistry || createJolocomRegistry()
     const remoteIdentity = await registry.resolve(
       keyIdToDid(receivedJWT.issuer),
     )
+
     const pubKey = getIssuerPublicKey(
       receivedJWT.issuer,
       remoteIdentity.didDocument,
     )
 
+    // First we make sure the signature on the interaction token is valid
     if (!(await SoftwareKeyProvider.verifyDigestable(pubKey, receivedJWT))) {
       throw new Error(ErrorCodes.IDWInvalidJWTSignature)
     }
 
-    if (sendJWT && receivedJWT.audience !== this.identity.did) {
-      throw new Error(ErrorCodes.IDWNotIntendedAudience)
-    }
-
-    if (
-      sendJWT &&
-      sendJWT.audience &&
-      receivedJWT.issuer !== sendJWT.audience
-    ) {
-      throw new Error(ErrorCodes.IDWNotCorrectResponder)
-    }
-
-    if (sendJWT && sendJWT.nonce !== receivedJWT.nonce) {
-      throw new Error(ErrorCodes.IDWIncorrectJWTNonce)
-    }
-
+    // TODO Should this somehow take into consideration the issuance date of the request
+    // if one is present?
     if (receivedJWT.expires < Date.now()) {
       throw new Error(ErrorCodes.IDWTokenExpired)
+    }
+
+    // In case the request object is provided (we are validating a response)
+    if (sentJWT) {
+      // We make sure the aud on the received message matches the issuer of the request
+      if (receivedJWT.audience !== sentJWT.signer.did) {
+        throw new Error(ErrorCodes.IDWNotCorrectResponder)
+      }
+
+      // We make sure the request and response share the same random nonce, i.e. part of one interaction
+      if (sentJWT.nonce !== receivedJWT.nonce) {
+        throw new Error(ErrorCodes.IDWIncorrectJWTNonce)
+      }
+    } else {
+      // No request object is provided (we are either validating a request, or a response in isolation)
+      // In which case, we make sure that if the request had a target audience, it matches our identity
+      if (receivedJWT.audience && receivedJWT.audience !== this.identity.did) {
+        throw new Error(ErrorCodes.IDWNotIntendedAudience)
+      }
     }
   }
 

--- a/ts/identityWallet/identityWallet.ts
+++ b/ts/identityWallet/identityWallet.ts
@@ -549,6 +549,14 @@ export class IdentityWallet {
       throw new Error(ErrorCodes.IDWNotIntendedAudience)
     }
 
+    if (
+      sendJWT &&
+      sendJWT.audience &&
+      recievedJWT.issuer !== sendJWT.audience
+    ) {
+      throw new Error(ErrorCodes.IDWNotCorrectResponder)
+    }
+
     if (sendJWT && sendJWT.nonce !== receivedJWT.nonce) {
       throw new Error(ErrorCodes.IDWIncorrectJWTNonce)
     }

--- a/ts/identityWallet/identityWallet.ts
+++ b/ts/identityWallet/identityWallet.ts
@@ -274,7 +274,7 @@ export class IdentityWallet {
     jwt.interactionType = InteractionType.Authentication
     jwt.timestampAndSetExpiry(authArgs.expires)
 
-    if (!recievedJWT && authArgs.aud) jwt.audience = authArgs.aud
+    if (!receivedJWT && authArgs.aud) jwt.audience = authArgs.aud
 
     return this.initializeAndSign(
       jwt,
@@ -560,7 +560,7 @@ export class IdentityWallet {
     if (
       sendJWT &&
       sendJWT.audience &&
-      recievedJWT.issuer !== sendJWT.audience
+      receivedJWT.issuer !== sendJWT.audience
     ) {
       throw new Error(ErrorCodes.IDWNotCorrectResponder)
     }


### PR DESCRIPTION
closes #397, adds "aud" as an option for all request messages and ensures that a response to a request with an audience is issued by that DID in validateJWT