### PR TITLE
fix: Verifying signature on Did Docs resolved through the registry

### DIFF
--- a/js/errors/index.d.ts
+++ b/js/errors/index.d.ts
@@ -19,5 +19,6 @@ export declare enum ErrorCodes {
     IDWNotCorrectResponder = "IDWNotCorrectResponder",
     IDWIncorrectJWTNonce = "IDWIncorrectJWTNonce",
     IDWTokenExpired = "IDWTokenExpired",
-    VCInvalidExpiryDate = "VCInvalidExpiryDate"
+    VCInvalidExpiryDate = "VCInvalidExpiryDate",
+    InvalidSignature = "InvalidSignature"
 }

--- a/ts/errors/index.ts
+++ b/ts/errors/index.ts
@@ -20,4 +20,5 @@ export enum ErrorCodes {
   IDWIncorrectJWTNonce = 'IDWIncorrectJWTNonce',
   IDWTokenExpired = 'IDWTokenExpired',
   VCInvalidExpiryDate = 'VCInvalidExpiryDate',
+  InvalidSignature = 'InvalidSignature'
 }

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -6,6 +6,7 @@ import { KeyTypes } from './vaultedKeyProvider/types'
 import { constraintFunctions } from './interactionTokens/credentialRequest'
 import { fuelKeyWithEther, getIssuerPublicKey } from './utils/helper'
 import { validateDigestable, validateDigestables } from './utils/validation'
+import { createJolocomRegistry } from './registries/jolocomRegistry'
 
 export const JolocomLib = {
   parse,


### PR DESCRIPTION
The functions to normalize and validate Json-Ld documents were defined in previous commits. This PR makes use of them to validate DID Documents as part of the resolution process.
