### PR TITLE
Add Interaction token type constant inside the JWT message payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "license": "MIT",
   "homepage": "https://github.com/jolocom/jolocom-lib#readme",
   "dependencies": {
-    "@jolocom/protocol-ts": "^0.3.0",
+    "@jolocom/protocol-ts": "^0.4.0",
     "base64url": "^3.0.1",
     "bip32": "^1.0.2",
     "bip39": "^3.0.1",

--- a/tests/data/interactionTokens/authentication.data.ts
+++ b/tests/data/interactionTokens/authentication.data.ts
@@ -1,4 +1,5 @@
 export const jsonAuthentication = {
   callbackURL: 'https://me.test.io',
   description: 'Test service usage',
+  type: 'authentication',
 }

--- a/tests/data/interactionTokens/credentialOffer.data.ts
+++ b/tests/data/interactionTokens/credentialOffer.data.ts
@@ -17,6 +17,7 @@ export const credentialOfferRequestCreationArgs = {
       },
     },
   ],
+  type: 'credentialOfferRequest',
 }
 export const credentialOfferResponseCreationArgs = {
   callbackURL,
@@ -25,4 +26,5 @@ export const credentialOfferResponseCreationArgs = {
       type: claimsMetadata.emailAddress.type[1],
     },
   ],
+  type: 'credentialOfferResponse',
 }

--- a/tests/data/interactionTokens/credentialReceive.data.ts
+++ b/tests/data/interactionTokens/credentialReceive.data.ts
@@ -2,4 +2,5 @@ import { credentialSet } from './credentialRequest.data'
 
 export const jsonCredReceive = {
   signedCredentials: credentialSet,
+  type: 'credentialsReceive',
 }

--- a/tests/data/interactionTokens/credentialRequest.data.ts
+++ b/tests/data/interactionTokens/credentialRequest.data.ts
@@ -26,6 +26,7 @@ export const simpleCredRequestJSON = {
       constraints: [{ '==': [{ var: 'issuer' }, mockIssuerDid] }],
     },
   ],
+  type: 'credentialRequest',
 }
 
 /* Fixture to test if validating against an empty constraint set returns true */

--- a/tests/data/interactionTokens/credentialResponse.data.ts
+++ b/tests/data/interactionTokens/credentialResponse.data.ts
@@ -3,9 +3,11 @@ import { credentialSet } from './credentialRequest.data'
 export const credentialResponseJSON = {
   callbackURL: 'https://test.io/auth/abc',
   suppliedCredentials: credentialSet,
+  type: 'credentialResponse',
 }
 
 export const emptyCredentialResponseJSON = {
   callbackURL: 'https://test.io/auth/abc',
   suppliedCredentials: [],
+  type: 'credentialResponse',
 }

--- a/tests/data/interactionTokens/jsonWebToken.data.ts
+++ b/tests/data/interactionTokens/jsonWebToken.data.ts
@@ -3,6 +3,8 @@ import { credentialSet } from './credentialRequest.data'
 
 /* Credential request wrapped in signed JWT*/
 
+/**/
+
 export const validSignedCredReqJWT = {
   header: { typ: 'JWT', alg: 'ES256K' },
   payload: {
@@ -15,7 +17,7 @@ export const validSignedCredReqJWT = {
     jti: '2a97b35fe74b5',
   },
   signature:
-    'd904b6ca775f555121012ed7ec55be5958703411f5e9af0d93f17994d5e3bb3b3afdbb49216ffc0b005562d928690e4c94803e9f17ac811480dc0fff46b28623',
+    '754a6e0607d2ad510dbfc014cc7d0596592bfc9f4d85ab399f88351085971b3a4dd7a1d15c945b3acf4ed7fc5a9bcee166ab0767749323d6441ea7b261910232',
 }
 
 export const invalidSignature =
@@ -46,15 +48,7 @@ export const invalidNonce = 'h'.repeat(16)
 /* Same credential request in base64 encoded form */
 
 export const encodedValidCredReqJWT =
-  'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.\
-eyJpbnRlcmFjdGlvblRva2VuIjp7ImNyZWRlbnRpYWxSZXF1aXJlbWVudHMiOlt7InR5cGUiOlsiQ3Jl\
-ZGVudGlhbCIsIlByb29mT2ZFbWFpbENyZWRlbnRpYWwiXSwiY29uc3RyYWludHMiOlt7Ij09IjpbeyJ2Y\
-XIiOiJpc3N1ZXIifSwiZGlkOmpvbG86YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWF\
-hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSJdfV19XSwiY2FsbGJhY2tVUkwiOiJodHRwOi8vdGVzdC5jb\
-20ifSwiaWF0IjowLCJleHAiOjM2MDAwMDAsImlzcyI6ImRpZDpqb2xvOmIyZDVkOGQ2Y2MxNDAwMzM0MTl\
-iNTRhMjM3YTVkYjUxNzEwNDM5ZjlmNDYyZDFmYzk4ZjY5OGVjYTdjZTk3Nzcja2V5cy0xIiwidHlwIjoiY3\
-JlZGVudGlhbFJlcXVlc3QiLCJqdGkiOiIyYTk3YjM1ZmU3NGI1In0.d904b6ca775f555121012ed7ec55b\
-e5958703411f5e9af0d93f17994d5e3bb3b3afdbb49216ffc0b005562d928690e4c94803e9f17ac811480dc0fff46b28623'
+  'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpbnRlcmFjdGlvblRva2VuIjp7InR5cGUiOiJjcmVkZW50aWFsUmVxdWVzdCIsImNyZWRlbnRpYWxSZXF1aXJlbWVudHMiOlt7InR5cGUiOlsiQ3JlZGVudGlhbCIsIlByb29mT2ZFbWFpbENyZWRlbnRpYWwiXSwiY29uc3RyYWludHMiOlt7Ij09IjpbeyJ2YXIiOiJpc3N1ZXIifSwiZGlkOmpvbG86YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSJdfV19XSwiY2FsbGJhY2tVUkwiOiJodHRwOi8vdGVzdC5jb20ifSwiaWF0IjowLCJleHAiOjM2MDAwMDAsImlzcyI6ImRpZDpqb2xvOmIyZDVkOGQ2Y2MxNDAwMzM0MTliNTRhMjM3YTVkYjUxNzEwNDM5ZjlmNDYyZDFmYzk4ZjY5OGVjYTdjZTk3Nzcja2V5cy0xIiwidHlwIjoiY3JlZGVudGlhbFJlcXVlc3QiLCJqdGkiOiIyYTk3YjM1ZmU3NGI1In0.754a6e0607d2ad510dbfc014cc7d0596592bfc9f4d85ab399f88351085971b3a4dd7a1d15c945b3acf4ed7fc5a9bcee166ab0767749323d6441ea7b261910232'
 
 export const expiredEncodedSimpleCredReqJWT =
   'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.\
@@ -68,4 +62,4 @@ Y3JlZGVudGlhbFJlcXVlc3QifQ.4fe903a33015a63a6d6e8a1054584e54b9f6e7ffea5ab196f940c
 29b7ffa14ef18a19af87c4d848db5dfa6d70e3a4d9b194da83e7eeaa3db0602e9d2d65c53d6'
 
 export const hashedValidCredReqJWT =
-  '96f55602967b22a28c6bc5a85dbba80aea67248623a9b8df8c118b6df84679da'
+  '6dd9a107b253968931e96b267e9a9315ee3ce38f5ccf05e6f954a0db8270d99e'

--- a/ts/identityWallet/identityWallet.ts
+++ b/ts/identityWallet/identityWallet.ts
@@ -4,7 +4,7 @@ import { SignedCredential } from '../credentials/signedCredential/signedCredenti
 import { ExclusivePartial, IIdentityWalletCreateArgs } from './types'
 import { Identity } from '../identity/identity'
 import { JSONWebToken } from '../interactionTokens/JSONWebToken'
-import { InteractionType } from '../interactionTokens/types'
+import { InteractionType, IInteractionToken } from '../interactionTokens/types'
 import { PaymentResponse } from '../interactionTokens/paymentResponse'
 import { PaymentRequest } from '../interactionTokens/paymentRequest'
 import { Authentication } from '../interactionTokens/authentication'
@@ -261,7 +261,7 @@ export class IdentityWallet {
    * @param pass - Password to decrypt the vaulted seed
    * @param received - optional received JSONWebToken Class
    */
-  private createMessage = async <T, R>(
+  private createMessage = async <T extends IInteractionToken, R extends IInteractionToken>(
     args: { message: T; typ: string; expires?: Date; aud?: string },
     pass: string,
     recieved?: JSONWebToken<R>,
@@ -294,7 +294,7 @@ export class IdentityWallet {
       pass,
     )
 
-  private makeRes = <T, R>(typ: string) => (
+  private makeRes = <T, R extends IInteractionToken>(typ: string) => (
     { expires, aud, ...message }: WithExtraOptions<T>,
     pass: string,
     recieved?: JSONWebToken<R>,
@@ -365,7 +365,7 @@ export class IdentityWallet {
    * @param receivedJWT - optional received JSONWebToken Class
    */
 
-  private async initializeAndSign<T, R>(
+  private async initializeAndSign<T extends IInteractionToken, R extends IInteractionToken>(
     jwt: JSONWebToken<T>,
     derivationPath: string,
     pass: string,
@@ -396,7 +396,7 @@ export class IdentityWallet {
    * @param customRegistry - optional custom registry
    */
 
-  public async validateJWT<T, R>(
+  public async validateJWT<T extends IInteractionToken, R extends IInteractionToken>(
     receivedJWT: JSONWebToken<T>,
     sentJWT?: JSONWebToken<R>,
     customRegistry?: IRegistry,

--- a/ts/interactionTokens/JSONWebToken.ts
+++ b/ts/interactionTokens/JSONWebToken.ts
@@ -7,7 +7,7 @@ import {
   Transform,
   Exclude,
 } from 'class-transformer'
-import { IJWTHeader } from './types'
+import { IJWTHeader, IInteractionToken } from './types'
 import { IJSONWebTokenAttrs, InteractionType } from './types'
 import { sha256 } from '../utils/crypto'
 import { IDigestable } from '../linkedDataSignature/types'
@@ -69,7 +69,7 @@ const convertPayload = <T>(args: TransformArgs) => ({
 /* Generic class encoding and decodes various interaction tokens as and from JSON web tokens */
 
 @Exclude()
-export class JSONWebToken<T> implements IDigestable {
+export class JSONWebToken<T extends IInteractionToken> implements IDigestable {
   /* ES256K stands for ec signatures on secp256k1, de facto standard */
   private _header: IJWTHeader = {
     typ: 'JWT',
@@ -173,7 +173,7 @@ export class JSONWebToken<T> implements IDigestable {
    * @returns {Object} - A json web token instance
    */
 
-  public static fromJWTEncodable<T>(toEncode: T): JSONWebToken<T> {
+  public static fromJWTEncodable<T extends IInteractionToken>(toEncode: T): JSONWebToken<T> {
     const jwt = new JSONWebToken<T>()
     jwt.interactionToken = toEncode
     return jwt
@@ -212,7 +212,7 @@ export class JSONWebToken<T> implements IDigestable {
    * @returns {Object} - Instance of JSONWebToken class
    */
 
-  public static decode<T>(jwt: string): JSONWebToken<T> {
+  public static decode<T extends IInteractionToken>(jwt: string): JSONWebToken<T> {
     return JSONWebToken.fromJSON<T>(decodeToken(jwt))
   }
 
@@ -251,7 +251,7 @@ export class JSONWebToken<T> implements IDigestable {
     return classToPlain(this) as IJSONWebTokenAttrs
   }
 
-  public static fromJSON<T>(json: IJSONWebTokenAttrs): JSONWebToken<T> {
+  public static fromJSON<T extends IInteractionToken>(json: IJSONWebTokenAttrs): JSONWebToken<T> {
     return plainToClass<JSONWebToken<T>, IJSONWebTokenAttrs>(JSONWebToken, json)
   }
 }

--- a/ts/interactionTokens/authentication.ts
+++ b/ts/interactionTokens/authentication.ts
@@ -1,5 +1,9 @@
 import { plainToClass, classToPlain, Expose, Exclude } from 'class-transformer'
-import { IAuthenticationAttrs } from './interactionTokens.types'
+import {
+  IAuthenticationAttrs,
+  IInteractionToken,
+  InteractionType,
+} from './interactionTokens.types'
 
 /**
  * @class
@@ -9,7 +13,10 @@ import { IAuthenticationAttrs } from './interactionTokens.types'
  */
 
 @Exclude()
-export class Authentication {
+export class Authentication implements IInteractionToken {
+  @Expose({ toPlainOnly: true })
+  readonly type = InteractionType.Authentication
+
   private _callbackURL: string
   private _description: string
 

--- a/ts/interactionTokens/credentialOfferRequest.ts
+++ b/ts/interactionTokens/credentialOfferRequest.ts
@@ -5,6 +5,8 @@ import {
   CredentialOfferMetadata,
   CredentialOfferRenderInfo,
   CredentialOfferRequestAttrs,
+  InteractionType,
+  IInteractionToken,
 } from './interactionTokens.types'
 
 /**
@@ -13,7 +15,10 @@ import {
  */
 
 @Exclude()
-export class CredentialOfferRequest {
+export class CredentialOfferRequest implements IInteractionToken {
+  @Expose({ toPlainOnly: true })
+  readonly type = InteractionType.CredentialOfferRequest
+
   private _callbackURL: string
   private _offeredCredentials: CredentialOffer[]
 

--- a/ts/interactionTokens/credentialOfferResponse.ts
+++ b/ts/interactionTokens/credentialOfferResponse.ts
@@ -2,6 +2,8 @@ import { classToPlain, plainToClass, Expose, Exclude } from 'class-transformer'
 import {
   CredentialOfferResponseAttrs,
   CredentialOfferResponseSelection,
+  IInteractionToken,
+  InteractionType,
 } from './interactionTokens.types'
 import { CredentialOfferRequest } from './credentialOfferRequest'
 
@@ -11,7 +13,10 @@ import { CredentialOfferRequest } from './credentialOfferRequest'
  */
 
 @Exclude()
-export class CredentialOfferResponse {
+export class CredentialOfferResponse implements IInteractionToken {
+  @Expose({ toPlainOnly: true })
+  readonly type = InteractionType.CredentialOfferResponse
+
   private _callbackURL: string
   private _selectedCredentials: CredentialOfferResponseSelection[]
 

--- a/ts/interactionTokens/credentialRequest.ts
+++ b/ts/interactionTokens/credentialRequest.ts
@@ -7,6 +7,8 @@ import {
   ICredentialRequest,
   IConstraint,
   Operator,
+  IInteractionToken,
+  InteractionType,
 } from './interactionTokens.types'
 import { ISignedCredentialAttrs } from '../credentials/signedCredential/types'
 
@@ -16,7 +18,10 @@ import { ISignedCredentialAttrs } from '../credentials/signedCredential/types'
  */
 
 @Exclude()
-export class CredentialRequest {
+export class CredentialRequest implements IInteractionToken {
+  @Expose({ toPlainOnly: true })
+  readonly type = InteractionType.CredentialRequest
+
   private _callbackURL: string
   private _credentialRequirements: ICredentialRequest[] = []
 

--- a/ts/interactionTokens/credentialResponse.ts
+++ b/ts/interactionTokens/credentialResponse.ts
@@ -5,7 +5,11 @@ import {
   Type,
   Exclude,
 } from 'class-transformer'
-import { ICredentialResponseAttrs } from './interactionTokens.types'
+import {
+  ICredentialResponseAttrs,
+  InteractionType,
+  IInteractionToken,
+} from './interactionTokens.types'
 import { SignedCredential } from '../credentials/signedCredential/signedCredential'
 import { CredentialRequest } from './credentialRequest'
 
@@ -14,7 +18,10 @@ import { CredentialRequest } from './credentialRequest'
  * Class representing a credential response. encodable as a JWT
  */
 @Exclude()
-export class CredentialResponse {
+export class CredentialResponse implements IInteractionToken {
+  @Expose({ toPlainOnly: true })
+  readonly type = InteractionType.CredentialResponse
+
   private _callbackURL: string
   private _suppliedCredentials: SignedCredential[]
 

--- a/ts/interactionTokens/credentialsReceive.ts
+++ b/ts/interactionTokens/credentialsReceive.ts
@@ -6,7 +6,11 @@ import {
   Exclude,
 } from 'class-transformer'
 import { SignedCredential } from '../credentials/signedCredential/signedCredential'
-import { ICredentialsReceiveAttrs } from './interactionTokens.types'
+import {
+  ICredentialsReceiveAttrs,
+  IInteractionToken,
+  InteractionType,
+} from './interactionTokens.types'
 
 /**
  * @class
@@ -16,7 +20,10 @@ import { ICredentialsReceiveAttrs } from './interactionTokens.types'
  */
 
 @Exclude()
-export class CredentialsReceive {
+export class CredentialsReceive implements IInteractionToken {
+  @Expose({ toPlainOnly: true })
+  readonly type = InteractionType.CredentialsReceive
+
   private _signedCredentials: SignedCredential[]
 
   /**

--- a/ts/interactionTokens/paymentRequest.ts
+++ b/ts/interactionTokens/paymentRequest.ts
@@ -1,5 +1,9 @@
 import { classToPlain, plainToClass, Expose, Exclude } from 'class-transformer'
-import { IPaymentRequestAttrs } from './interactionTokens.types'
+import {
+  IPaymentRequestAttrs,
+  InteractionType,
+  IInteractionToken,
+} from './interactionTokens.types'
 import { ITransactionEncodable, TransactionOptions } from '../contracts/types'
 
 /**
@@ -8,7 +12,11 @@ import { ITransactionEncodable, TransactionOptions } from '../contracts/types'
  */
 
 @Exclude()
-export class PaymentRequest implements ITransactionEncodable {
+export class PaymentRequest
+  implements ITransactionEncodable, IInteractionToken {
+  @Expose({ toPlainOnly: true })
+  readonly type = InteractionType.PaymentRequest
+
   private _callbackURL: string
   private _transactionOptions: TransactionOptions
   private _description: string

--- a/ts/interactionTokens/paymentResponse.ts
+++ b/ts/interactionTokens/paymentResponse.ts
@@ -1,5 +1,9 @@
 import { classToPlain, plainToClass, Expose, Exclude } from 'class-transformer'
-import { IPaymentResponseAttrs } from './interactionTokens.types'
+import {
+  IPaymentResponseAttrs,
+  IInteractionToken,
+  InteractionType,
+} from './interactionTokens.types'
 
 /**
  * @class
@@ -7,7 +11,10 @@ import { IPaymentResponseAttrs } from './interactionTokens.types'
  */
 
 @Exclude()
-export class PaymentResponse {
+export class PaymentResponse implements IInteractionToken {
+  @Expose({ toPlainOnly: true })
+  readonly type = InteractionType.PaymentResponse
+
   private _txHash: string
 
   @Expose()

--- a/ts/ipfs/ipfs.ts
+++ b/ts/ipfs/ipfs.ts
@@ -69,6 +69,7 @@ export class IpfsStorageAgent implements IIpfsConnector {
     const endpoint = `${this.endpoint}/api/v0/add?pin=${pin}`
 
     const serializedData = this.serializeJSON(data)
+    // @ts-ignore
     const { Hash } = await this.postRequest(endpoint, serializedData).then(
       res => res.json(),
     )

--- a/ts/parse/parse.ts
+++ b/ts/parse/parse.ts
@@ -4,7 +4,10 @@ import { SignedCredential } from '../credentials/signedCredential/signedCredenti
 import { ICredentialAttrs } from '../credentials/credential/types'
 import { ISignedCredentialAttrs } from '../credentials/signedCredential/types'
 import { JSONWebToken } from '../interactionTokens/JSONWebToken'
-import { IJSONWebTokenAttrs } from '../interactionTokens/types'
+import {
+  IJSONWebTokenAttrs,
+  IInteractionToken,
+} from '../interactionTokens/types'
 
 /**
  * Aggregates parsing methods for easier access
@@ -14,8 +17,10 @@ import { IJSONWebTokenAttrs } from '../interactionTokens/types'
 
 export interface ParseMethods {
   interactionToken: {
-    fromJWT: <T>(jwt: string) => JSONWebToken<T>
-    fromJSON: <T>(json: IJSONWebTokenAttrs) => JSONWebToken<T>
+    fromJWT: <T extends IInteractionToken>(jwt: string) => JSONWebToken<T>
+    fromJSON: <T extends IInteractionToken>(
+      json: IJSONWebTokenAttrs,
+    ) => JSONWebToken<T>
   }
   credential: (json: ICredentialAttrs) => Credential
   signedCredential: (json: ISignedCredentialAttrs) => SignedCredential

--- a/yarn.lock
+++ b/yarn.lock
@@ -137,10 +137,10 @@
     resolve-from "^5.0.0"
     resolve-global "^1.0.0"
 
-"@jolocom/protocol-ts@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@jolocom/protocol-ts/-/protocol-ts-0.3.0.tgz#28334bf65fdedda0f6ea90b54be4fa0a02234495"
-  integrity sha512-uEFDU0CnIBq/0AEmXQVJmwq3cdRrvWOdNQPz/WkODO9IG0MathZ6rEZX8f1gt4QMuCJ0uBcGRY5u3YoJx+gq6g==
+"@jolocom/protocol-ts@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@jolocom/protocol-ts/-/protocol-ts-0.4.0.tgz#152c4b23b9802a78bd98fbe18847d764f51a91f0"
+  integrity sha512-meKpwdHgWgkc2sgvbFYViIJN94+HKDsSqK1Xf7TBoiHGWHoMO95AbGNwOg/bE5+FnyJAQACa0wJmSC0GOK8ECA==
   dependencies:
     cred-types-jolocom-core "^0.0.11"
 


### PR DESCRIPTION
This simplifies life in SDK internals, at the lower ("purer") layers of the `InteractionManager` after the JWT is peeled away.
The the message ("JWT payload") lacks any type information, creating a need to pass the type around along with the actual message ("token"), and also creating an unnecessary need for typescript guards and what not.

This is not a full solution yet though, but a first step