### PR TITLE
feat(registry): improve API for passing custom components to the registry + custom resolver

### DIFF
--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -6,7 +6,7 @@ export declare const JolocomLib: {
     parse: import("./parse/parse").ParseMethods;
     registries: {
         jolocom: {
-            create: (configuration?: import("./registries/types").IRegistryStaticCreationArgs) => import("./registries/jolocomRegistry").JolocomRegistry;
+            create: (configuration?: Partial<import("./registries/types").IRegistryStaticCreationArgs>) => import("./registries/jolocomRegistry").JolocomRegistry;
         };
     };
     KeyProvider: typeof SoftwareKeyProvider;

--- a/js/registries/index.d.ts
+++ b/js/registries/index.d.ts
@@ -1,5 +1,5 @@
 export declare const registries: {
     jolocom: {
-        create: (configuration?: import("./types").IRegistryStaticCreationArgs) => import("./jolocomRegistry").JolocomRegistry;
+        create: (configuration?: Partial<import("./types").IRegistryStaticCreationArgs>) => import("./jolocomRegistry").JolocomRegistry;
     };
 };

--- a/js/registries/jolocomRegistry.d.ts
+++ b/js/registries/jolocomRegistry.d.ts
@@ -18,5 +18,5 @@ export declare class JolocomRegistry implements IRegistry {
     authenticate(vaultedKeyProvider: IVaultedKeyProvider, derivationArgs: IKeyDerivationArgs, did?: string): Promise<IdentityWallet>;
     private resolveSafe;
 }
-export declare const createJolocomRegistry: (configuration?: IRegistryStaticCreationArgs) => JolocomRegistry;
-export declare const jolocomResolver: (additionalResolver?: {}) => Resolver;
+export declare const jolocomResolver: () => Resolver;
+export declare const createJolocomRegistry: (configuration?: Partial<IRegistryStaticCreationArgs>) => JolocomRegistry;

--- a/js/registries/types.d.ts
+++ b/js/registries/types.d.ts
@@ -4,6 +4,7 @@ import { IdentityWallet } from '../identityWallet/identityWallet';
 import { IVaultedKeyProvider, IKeyDerivationArgs } from '../vaultedKeyProvider/types';
 import { Identity } from '../identity/identity';
 import { IContractsAdapter, IContractsGateway } from '../contracts/types';
+import { Resolver } from 'did-resolver';
 export interface IRegistryStaticCreationArgs {
     contracts: {
         adapter: IContractsAdapter;
@@ -11,6 +12,7 @@ export interface IRegistryStaticCreationArgs {
     };
     ipfsConnector: IIpfsConnector;
     ethereumConnector: IEthereumConnector;
+    resolver: Resolver;
 }
 export interface IRegistryCommitArgs {
     vaultedKeyProvider: IVaultedKeyProvider;

--- a/tests/integration/identity.integration.ts
+++ b/tests/integration/identity.integration.ts
@@ -51,6 +51,7 @@ before(async () => {
     ipfsConnector: new IpfsStorageAgent(testIpfsConfig),
     ethereumConnector: new EthResolver(testEthereumConfig),
     contracts: { gateway, adapter },
+    resolver: testResolver
   })
 
   testResolver = new Resolver(
@@ -60,8 +61,6 @@ before(async () => {
       `${testIpfsConfig.protocol}://${testIpfsConfig.host}:${testIpfsConfig.port}`
     )
   )
-
-  jolocomRegistry.resolver = testResolver
 
   userIdentityWallet = await jolocomRegistry.create(userVault, userPass)
   serviceIdentityWallet = await jolocomRegistry.create(

--- a/tests/integration/identity.integration.ts
+++ b/tests/integration/identity.integration.ts
@@ -69,10 +69,6 @@ before(async () => {
   )
 })
 
-after(() => {
-  process.exit(0)
-})
-
 describe('Integration Test - Create, Resolve, Public Profile', () => {
   it('should correctly create user and service identities', async () => {
     const remoteUserIdentity = await jolocomRegistry.resolve(

--- a/ts/registries/jolocomRegistry.ts
+++ b/ts/registries/jolocomRegistry.ts
@@ -239,26 +239,40 @@ export class JolocomRegistry implements IRegistry {
   }
 }
 
+export const jolocomResolver = () => new Resolver(getResolver())
+
+const defaultJolocomRegistryConfig = {
+  ipfsConnector: jolocomIpfsStorageAgent,
+  ethereumConnector: jolocomEthereumResolver,
+  contracts: {
+    adapter: jolocomContractsAdapter,
+    gateway: jolocomContractsGateway,
+  },
+  resolver: jolocomResolver()
+}
+
 /**
  * Returns a instance of the Jolocom registry given connector, defaults to Jolocom defined connectors.
  * @param configuration - Connectors required for smart contract, storage, and anchoring interactions
  * @param configuration.ipfsConnector - Instance of class implementing the {@link IIpfsConnector} interface
  * @param configuration.ethereumConnector - Instance of class implementing the {@link IEthereumConnector} interface
  * @param configuration.contracts - Classes for interacting with Smart ContractsAdapter, implementing {@link IContractsGateway} and {@link IContractsAdapter}
+ * @param configuration.resolver - Classes for resolving did documents
  * @example `const registry = createJolocomRegistry()`
  */
 
 export const createJolocomRegistry = (
-  configuration: IRegistryStaticCreationArgs = {
-    ipfsConnector: jolocomIpfsStorageAgent,
-    ethereumConnector: jolocomEthereumResolver,
-    contracts: {
-      adapter: jolocomContractsAdapter,
-      gateway: jolocomContractsGateway,
-    },
-  },
+  configuration: Partial<IRegistryStaticCreationArgs> = {}
 ): JolocomRegistry => {
-  const { ipfsConnector, contracts, ethereumConnector } = configuration
+  const withDefaults = {
+    ...defaultJolocomRegistryConfig,
+    ...configuration,
+    contracts: {
+      ...defaultJolocomRegistryConfig.contracts,
+      ...(configuration.contracts || {})
+    }
+  }
+  const { ipfsConnector, contracts, ethereumConnector } = withDefaults
   const jolocomRegistry = new JolocomRegistry()
 
   jolocomRegistry.ipfsConnector = ipfsConnector
@@ -270,8 +284,3 @@ export const createJolocomRegistry = (
   return jolocomRegistry
 }
 
-export const jolocomResolver = (additionalResolver = {}): Resolver => {
-  const jolo = getResolver()
-  // TODO Do we overwrite or not?
-  return new Resolver({ ...jolo, ...additionalResolver })
-}

--- a/ts/registries/types.ts
+++ b/ts/registries/types.ts
@@ -7,6 +7,7 @@ import {
 } from '../vaultedKeyProvider/types'
 import { Identity } from '../identity/identity'
 import { IContractsAdapter, IContractsGateway } from '../contracts/types'
+import { Resolver } from 'did-resolver'
 
 export interface IRegistryStaticCreationArgs {
   contracts: {
@@ -15,6 +16,7 @@ export interface IRegistryStaticCreationArgs {
   }
   ipfsConnector: IIpfsConnector
   ethereumConnector: IEthereumConnector
+  resolver: Resolver
 }
 
 export interface IRegistryCommitArgs {


### PR DESCRIPTION
Allows the user to configure the resolver that should be used in the registry. Somehow I didn't implement in the previous PR.