### PR TITLE
Passive resolve

### DIFF
--- a/js/identityWallet/identityWallet.d.ts
+++ b/js/identityWallet/identityWallet.d.ts
@@ -16,6 +16,7 @@ import { IResolver } from '../didMethods/types';
 declare type WithExtraOptions<T> = T & {
     expires?: Date;
     aud?: string;
+    pca?: string;
 };
 export declare class IdentityWallet {
     private _identity;
@@ -47,18 +48,19 @@ export declare class IdentityWallet {
             typ: string;
             expires?: Date;
             aud?: string;
+            pca?: string;
         }, pass: string, recieved?: JSONWebToken<R>) => Promise<JSONWebToken<T_1>>;
         interactionTokens: {
             request: {
-                auth: ({ expires, aud, ...message }: WithExtraOptions<ExclusivePartial<IAuthenticationAttrs, "callbackURL">>, pass: string) => Promise<JSONWebToken<any>>;
-                offer: ({ expires, aud, ...message }: WithExtraOptions<CredentialOfferRequestAttrs>, pass: string) => Promise<JSONWebToken<any>>;
-                share: ({ expires, aud, ...message }: WithExtraOptions<ICredentialRequestAttrs>, pass: string) => Promise<JSONWebToken<any>>;
+                auth: ({ expires, aud, pca, ...message }: WithExtraOptions<ExclusivePartial<IAuthenticationAttrs, "callbackURL">>, pass: string) => Promise<JSONWebToken<any>>;
+                offer: ({ expires, aud, pca, ...message }: WithExtraOptions<CredentialOfferRequestAttrs>, pass: string) => Promise<JSONWebToken<any>>;
+                share: ({ expires, aud, pca, ...message }: WithExtraOptions<ICredentialRequestAttrs>, pass: string) => Promise<JSONWebToken<any>>;
             };
             response: {
-                auth: ({ expires, aud, ...message }: WithExtraOptions<ExclusivePartial<IAuthenticationAttrs, "callbackURL">>, pass: string, recieved?: JSONWebToken<Authentication>) => Promise<JSONWebToken<any>>;
-                offer: ({ expires, aud, ...message }: WithExtraOptions<CredentialOfferResponseAttrs>, pass: string, recieved?: JSONWebToken<CredentialOfferRequest>) => Promise<JSONWebToken<any>>;
-                share: ({ expires, aud, ...message }: WithExtraOptions<ICredentialResponseAttrs>, pass: string, recieved?: JSONWebToken<CredentialRequest>) => Promise<JSONWebToken<any>>;
-                issue: ({ expires, aud, ...message }: WithExtraOptions<ICredentialsReceiveAttrs>, pass: string, recieved?: JSONWebToken<CredentialOfferResponse>) => Promise<JSONWebToken<any>>;
+                auth: ({ expires, aud, pca, ...message }: WithExtraOptions<ExclusivePartial<IAuthenticationAttrs, "callbackURL">>, pass: string, recieved?: JSONWebToken<Authentication>) => Promise<JSONWebToken<any>>;
+                offer: ({ expires, aud, pca, ...message }: WithExtraOptions<CredentialOfferResponseAttrs>, pass: string, recieved?: JSONWebToken<CredentialOfferRequest>) => Promise<JSONWebToken<any>>;
+                share: ({ expires, aud, pca, ...message }: WithExtraOptions<ICredentialResponseAttrs>, pass: string, recieved?: JSONWebToken<CredentialRequest>) => Promise<JSONWebToken<any>>;
+                issue: ({ expires, aud, pca, ...message }: WithExtraOptions<ICredentialsReceiveAttrs>, pass: string, recieved?: JSONWebToken<CredentialOfferResponse>) => Promise<JSONWebToken<any>>;
             };
         };
     };

--- a/js/interactionTokens/JSONWebToken.d.ts
+++ b/js/interactionTokens/JSONWebToken.d.ts
@@ -16,6 +16,7 @@ interface IPayloadSection<T> {
     iss?: string;
     aud?: string;
     typ?: string;
+    pca?: string;
     interactionToken?: T;
 }
 export declare class JSONWebToken<T> implements IDigestable {

--- a/ts/identityWallet/identityWallet.ts
+++ b/ts/identityWallet/identityWallet.ts
@@ -59,6 +59,7 @@ import { IResolver } from '../didMethods/types'
 type WithExtraOptions<T> = T & {
   expires?: Date
   aud?: string
+  pca?: string
 }
 
 /**
@@ -213,20 +214,21 @@ export class IdentityWallet {
    * @param received - optional received JSONWebToken Class
    */
   private createMessage = async <T, R>(
-    args: { message: T; typ: string; expires?: Date; aud?: string },
+    args: { message: T; typ: string; expires?: Date; aud?: string, pca?: string },
     pass: string,
     recieved?: JSONWebToken<R>,
   ) => {
     const jwt = JSONWebToken.fromJWTEncodable(args.message)
     jwt.interactionType = args.typ
     if (args.aud) jwt.audience = args.aud
+    if (args.pca) jwt.payload.pca = args.pca
     jwt.timestampAndSetExpiry(args.expires)
 
     return this.initializeAndSign(jwt, pass, recieved)
   }
 
   private makeReq = <T>(typ: string) => (
-    { expires, aud, ...message }: WithExtraOptions<T>,
+    { expires, aud, pca, ...message }: WithExtraOptions<T>,
     pass: string,
   ) =>
     this.createMessage(
@@ -236,12 +238,13 @@ export class IdentityWallet {
         typ,
         expires,
         aud,
+        pca
       },
       pass,
     )
 
   private makeRes = <T, R>(typ: string) => (
-    { expires, aud, ...message }: WithExtraOptions<T>,
+    { expires, aud, pca, ...message }: WithExtraOptions<T>,
     pass: string,
     recieved?: JSONWebToken<R>,
   ) =>
@@ -252,6 +255,7 @@ export class IdentityWallet {
         typ,
         expires,
         aud,
+        pca
       },
       pass,
       recieved,

--- a/ts/interactionTokens/JSONWebToken.ts
+++ b/ts/interactionTokens/JSONWebToken.ts
@@ -49,6 +49,8 @@ interface IPayloadSection<T> {
   iss?: string
   aud?: string
   typ?: string
+  // Proof of Control Authority
+  pca?: string
   interactionToken?: T
 }
 


### PR DESCRIPTION
adds a field to JWTs intended to hold a proof of control authority (e.g. peer-did deltas, KERI key events), for "invisible" direct mode exchange