### PR TITLE
allow jolo-like did methods with a different prefix

### DIFF
--- a/js/didMethods/jolo/index.d.ts
+++ b/js/didMethods/jolo/index.d.ts
@@ -3,10 +3,11 @@ import { IDidMethod } from '../types';
 import { JolocomResolver } from './resolver';
 import { JolocomRegistrar } from './registrar';
 export declare class JoloDidMethod implements IDidMethod {
-    prefix: string;
+    private _prefix;
     resolver: JolocomResolver;
     registrar: JolocomRegistrar;
-    constructor(providerUrl?: string, contractAddress?: string, ipfsHost?: string);
+    constructor(providerUrl?: string, contractAddress?: string, ipfsHost?: string, prefix?: string);
+    readonly prefix: string;
     recoverFromSeed(seed: Buffer, newPassword: string): Promise<{
         identityWallet: import("../../identityWallet/identityWallet").IdentityWallet;
         succesfullyResolved: boolean;

--- a/js/didMethods/jolo/recovery.d.ts
+++ b/js/didMethods/jolo/recovery.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="node" />
 import { EncryptedWalletUtils, SoftwareKeyProvider } from '@jolocom/vaulted-key-provider';
-export declare const recoverJoloKeyProviderFromSeed: (seed: Buffer, newPassword: string, impl: EncryptedWalletUtils, originalDid?: string) => Promise<SoftwareKeyProvider>;
+export declare const recoverJoloKeyProviderFromSeed: (seed: Buffer, newPassword: string, impl: EncryptedWalletUtils, originalDid?: string, prefix?: string) => Promise<SoftwareKeyProvider>;

--- a/js/didMethods/jolo/registrar.d.ts
+++ b/js/didMethods/jolo/registrar.d.ts
@@ -4,9 +4,10 @@ import { SignedCredential } from '../../credentials/signedCredential/signedCrede
 import { IRegistrar } from '../types';
 import { SoftwareKeyProvider } from '@jolocom/vaulted-key-provider';
 export declare class JolocomRegistrar implements IRegistrar {
-    prefix: string;
+    private _prefix;
     registrarFns: ReturnType<typeof getRegistrar>;
-    constructor(providerUrl?: string, contractAddress?: string, ipfsHost?: string);
+    constructor(providerUrl?: string, contractAddress?: string, ipfsHost?: string, prefix?: string);
+    readonly prefix: string;
     create(keyProvider: SoftwareKeyProvider, password: string): Promise<Identity>;
     didDocumentFromKeyProvider(keyProvider: SoftwareKeyProvider, password: string): Promise<Identity>;
     updatePublicProfile(keyProvider: SoftwareKeyProvider, password: string, identity: Identity, publicProfile: SignedCredential): Promise<boolean>;

--- a/js/didMethods/jolo/resolver.d.ts
+++ b/js/didMethods/jolo/resolver.d.ts
@@ -1,8 +1,9 @@
 import { IResolver } from '../types';
 import { Identity } from '../../identity/identity';
 export declare class JolocomResolver implements IResolver {
-    prefix: string;
+    private _prefix;
     private resolutionFunctions;
-    constructor(providerUrl?: string, contractAddress?: string, ipfsHost?: string);
+    constructor(providerUrl?: string, contractAddress?: string, ipfsHost?: string, prefix?: string);
+    readonly prefix: string;
     resolve(did: string): Promise<Identity>;
 }

--- a/js/didMethods/jolo/utils.d.ts
+++ b/js/didMethods/jolo/utils.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="node" />
-export declare function publicKeyToJoloDID(publicKey: Buffer): string;
+export declare function publicKeyToDID(publicKey: Buffer, prefix: string): string;

--- a/js/identity/didDocument/didDocument.d.ts
+++ b/js/identity/didDocument/didDocument.d.ts
@@ -32,7 +32,7 @@ export declare class DidDocument implements IDigestable {
     addPublicKeySection(section: PublicKeySection): void;
     addServiceEndpoint(endpoint: ServiceEndpointsSection): void;
     resetServiceEndpoints(): void;
-    static fromPublicKey(publicKey: Buffer): Promise<DidDocument>;
+    static fromPublicKey(publicKey: Buffer, prefix?: string): Promise<DidDocument>;
     sign(vaultedKeyProvider: IVaultedKeyProvider, signConfig: IKeyRefArgs): Promise<void>;
     asBytes(): Promise<Buffer>;
     digest(): Promise<Buffer>;

--- a/js/identity/identity.d.ts
+++ b/js/identity/identity.d.ts
@@ -1,9 +1,11 @@
 import { DidDocument } from './didDocument/didDocument';
 import { SignedCredential } from '../credentials/signedCredential/signedCredential';
 import { IIdentityCreateArgs } from './types';
+import { IDidDocumentAttrs } from './didDocument/types';
+import { ISignedCredentialAttrs } from '../credentials/signedCredential/types';
 interface IdentityAttributes {
-    didDocument: DidDocument;
-    publicProfileCredential?: SignedCredential;
+    didDocument: IDidDocumentAttrs;
+    publicProfile?: ISignedCredentialAttrs;
 }
 export declare class Identity {
     private _didDocument;

--- a/ts/didMethods/jolo/index.ts
+++ b/ts/didMethods/jolo/index.ts
@@ -7,7 +7,7 @@ import { walletUtils } from '@jolocom/native-core'
 import { authAsIdentityFromKeyProvider } from '../utils'
 
 export class JoloDidMethod implements IDidMethod {
-  public prefix = 'jolo'
+  private _prefix: string
   public resolver: JolocomResolver
   public registrar: JolocomRegistrar
 
@@ -15,13 +15,21 @@ export class JoloDidMethod implements IDidMethod {
     providerUrl = PROVIDER_URL,
     contractAddress = CONTRACT_ADDRESS,
     ipfsHost = IPFS_ENDPOINT,
+    prefix = 'jolo'
   ) {
-    this.resolver = new JolocomResolver(providerUrl, contractAddress, ipfsHost)
+    this.resolver = new JolocomResolver(providerUrl, contractAddress, ipfsHost, prefix)
     this.registrar = new JolocomRegistrar(
       providerUrl,
       contractAddress,
       ipfsHost,
+      prefix
     )
+
+    this._prefix = prefix
+  }
+
+  get prefix(): string {
+    return this._prefix
   }
 
   public async recoverFromSeed(seed: Buffer, newPassword: string) {

--- a/ts/didMethods/jolo/recovery.ts
+++ b/ts/didMethods/jolo/recovery.ts
@@ -5,7 +5,7 @@ import {
 } from '@jolocom/vaulted-key-provider'
 import { KEY_PATHS, KEY_REFS } from './constants'
 import { fromMasterSeed } from 'hdkey'
-import { publicKeyToJoloDID } from './utils'
+import { publicKeyToDID } from './utils'
 
 const { JOLO_DERIVATION_PATH, ETH_DERIVATION_PATH } = KEY_PATHS
 const { SIGNING_KEY_REF, ENCRYPTION_KEY_REF, ANCHOR_KEY_REF } = KEY_REFS
@@ -15,10 +15,11 @@ export const recoverJoloKeyProviderFromSeed = async (
   newPassword: string,
   impl: EncryptedWalletUtils,
   originalDid?: string,
+  prefix: string = 'jolo'
 ): Promise<SoftwareKeyProvider> => {
   const joloKeys = fromMasterSeed(seed).derive(JOLO_DERIVATION_PATH)
   const ethKeys = fromMasterSeed(seed).derive(ETH_DERIVATION_PATH)
-  const did = originalDid || publicKeyToJoloDID(joloKeys.publicKey)
+  const did = originalDid || publicKeyToDID(joloKeys.publicKey, prefix)
 
   const skp = await SoftwareKeyProvider.newEmptyWallet(impl, did, newPassword)
 

--- a/ts/didMethods/jolo/registrar.ts
+++ b/ts/didMethods/jolo/registrar.ts
@@ -17,7 +17,7 @@ import {
 } from '@jolocom/vaulted-key-provider'
 import { validateDigestable } from '../../utils/validation'
 import { KEY_REFS } from './constants'
-import { publicKeyToJoloDID } from './utils'
+import { publicKeyToDID } from './utils'
 import { addHexPrefix } from 'ethereumjs-util'
 
 const { SIGNING_KEY_REF, ANCHOR_KEY_REF, ENCRYPTION_KEY_REF } = KEY_REFS
@@ -91,8 +91,9 @@ export class JolocomRegistrar implements IRegistrar {
         SIGNING_KEY_REF,
       )
 
-      const did = publicKeyToJoloDID(
+      const did = publicKeyToDID(
         Buffer.from(signingKey.publicKeyHex, 'hex'),
+        this.prefix
       )
 
       await keyProvider.changeId(password, did)

--- a/ts/didMethods/jolo/registrar.ts
+++ b/ts/didMethods/jolo/registrar.ts
@@ -23,15 +23,21 @@ import { addHexPrefix } from 'ethereumjs-util'
 const { SIGNING_KEY_REF, ANCHOR_KEY_REF, ENCRYPTION_KEY_REF } = KEY_REFS
 
 export class JolocomRegistrar implements IRegistrar {
-  public prefix = 'jolo'
+  private _prefix: string
   public registrarFns: ReturnType<typeof getRegistrar>
 
   constructor(
     providerUrl = PROVIDER_URL,
     contractAddress = CONTRACT_ADDRESS,
     ipfsHost = IPFS_ENDPOINT,
+    prefix = 'jolo'
   ) {
     this.registrarFns = getRegistrar(providerUrl, contractAddress, ipfsHost)
+    this._prefix = prefix
+  }
+
+  get prefix() {
+    return this._prefix
   }
 
   async create(keyProvider: SoftwareKeyProvider, password: string) {
@@ -192,7 +198,7 @@ export class JolocomRegistrar implements IRegistrar {
       ({ type }) =>
         type ===
         claimsMetadata.publicProfile.type[
-          claimsMetadata.publicProfile.type.length - 1
+        claimsMetadata.publicProfile.type.length - 1
         ],
     )
 

--- a/ts/didMethods/jolo/resolver.ts
+++ b/ts/didMethods/jolo/resolver.ts
@@ -10,20 +10,20 @@ import { parseAndValidate } from '../../parse/parseAndValidate'
 type Resolve = (did: string) => Promise<DIDDocument>
 
 export class JolocomResolver implements IResolver {
-  prefix = 'jolo'
-
+  private _prefix: string
   private resolutionFunctions: {
     resolve: Resolve
     getPublicProfile: (didDoc: DIDDocument) => any
   } = {
-    resolve: undefined,
-    getPublicProfile: undefined,
-  }
+      resolve: undefined,
+      getPublicProfile: undefined,
+    }
 
   constructor(
     providerUrl = PROVIDER_URL,
     contractAddress = CONTRACT_ADDRESS,
     ipfsHost = IPFS_ENDPOINT,
+    prefix = 'jolo'
   ) {
     this.resolutionFunctions.getPublicProfile = (didDoc: DIDDocument) =>
       getPublicProfile(didDoc, ipfsHost)
@@ -32,6 +32,12 @@ export class JolocomResolver implements IResolver {
       new Resolver(getResolver(providerUrl, contractAddress, ipfsHost)).resolve(
         did,
       )
+
+    this._prefix = prefix
+  }
+
+  get prefix() {
+    return this._prefix
   }
 
   async resolve(did: string) {

--- a/ts/didMethods/jolo/utils.ts
+++ b/ts/didMethods/jolo/utils.ts
@@ -7,8 +7,8 @@ import { keccak256 } from 'ethereumjs-util'
  * @ignore
  */
 
-export function publicKeyToJoloDID(publicKey: Buffer): string {
-  const prefix = 'did:jolo:'
+export function publicKeyToDID(publicKey: Buffer, prefix: string): string {
+  const method = `did:${prefix}:`
   const suffix = keccak256(publicKey)
-  return prefix + suffix.toString('hex')
+  return method + suffix.toString('hex')
 }

--- a/ts/identity/didDocument/didDocument.ts
+++ b/ts/identity/didDocument/didDocument.ts
@@ -24,7 +24,7 @@ import {
 import { ContextEntry } from '@jolocom/protocol-ts'
 import { ISigner } from '../../credentials/signedCredential/types'
 import { IVaultedKeyProvider, IKeyRefArgs } from '@jolocom/vaulted-key-provider'
-import { publicKeyToJoloDID } from '../../didMethods/jolo/utils'
+import { publicKeyToDID } from '../../didMethods/jolo/utils'
 
 /**
  * Class modelling a Did Document
@@ -360,8 +360,8 @@ export class DidDocument implements IDigestable {
    * @example `const didDocument = DidDocument.fromPublicKey(Buffer.from('abc...ffe', 'hex'))`
    */
 
-  public static async fromPublicKey(publicKey: Buffer): Promise<DidDocument> {
-    const did = publicKeyToJoloDID(publicKey)
+  public static async fromPublicKey(publicKey: Buffer, prefix: string = 'jolo'): Promise<DidDocument> {
+    const did = publicKeyToDID(publicKey, prefix)
     const keyId = `${did}#keys-1`
 
     const didDocument = new DidDocument()


### PR DESCRIPTION
allows for DID methods with the same architecture as `did:jolo` but a different anchoring network to easily integrate with the library