### PR TITLE
fix(sigs): ensure b64 signatures have no padding

### DIFF
--- a/js/identity/identity.d.ts
+++ b/js/identity/identity.d.ts
@@ -1,9 +1,11 @@
 import { DidDocument } from './didDocument/didDocument';
 import { SignedCredential } from '../credentials/signedCredential/signedCredential';
 import { IIdentityCreateArgs } from './types';
+import { IDidDocumentAttrs } from './didDocument/types';
+import { ISignedCredentialAttrs } from '../credentials/signedCredential/types';
 interface IdentityAttributes {
-    didDocument: DidDocument;
-    publicProfileCredential?: SignedCredential;
+    didDocument: IDidDocumentAttrs;
+    publicProfile?: ISignedCredentialAttrs;
 }
 export declare class Identity {
     private _didDocument;

--- a/ts/identityWallet/identityWallet.ts
+++ b/ts/identityWallet/identityWallet.ts
@@ -328,7 +328,7 @@ export class IdentityWallet {
       await jwt.asBytes(),
     ) // TODO Also, are the signatures hex or b64?
 
-    jwt.signature = base64url.stringify(signature)
+    jwt.signature = base64url.stringify(signature, { pad: false })
 
     return jwt
   }


### PR DESCRIPTION
#438 left the signatures on JWTs with padding `=` characters. this pr removes them