### PR TITLE
Hotfix/pin class transformer

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@jolocom/vaulted-key-provider": "^0.7.4",
     "@types/sinon": "^9.0.5",
     "bip39": "^3.0.2",
-    "class-transformer": "^0.3.1",
+    "class-transformer": "0.3.1",
     "create-hash": "^1.2.0",
     "did-resolver": "2.0.0",
     "ethereumjs-util": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jolocom-lib",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Unified library for interacting with the Jolocom identity solution",
   "main": "js/index.js",
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1491,7 +1491,7 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-class-transformer@^0.3.1:
+class-transformer@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.3.1.tgz#ee681a5439ff2230fc57f5056412d3befa70d597"
   integrity sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA==


### PR DESCRIPTION
Pins the class-transformer dependency version. Breaking changes were introduced in a patch release, as per:

- https://github.com/typestack/class-transformer/blob/develop/CHANGELOG.md#032-breaking-change---2021-01-14
- https://github.com/typestack/class-transformer/issues/553