### PR TITLE
Update @jolocom-protocol-ts and replace exported type definitions

### DIFF
--- a/js/identity/didDocument/didDocument.d.ts
+++ b/js/identity/didDocument/didDocument.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import { IDidDocumentAttrs } from './types';
+import { IDidDocumentAttrs } from '@jolocom/protocol-ts';
 import { AuthenticationSection, PublicKeySection, ServiceEndpointsSection } from './sections';
 import { IDigestable, ILinkedDataSignature } from '../../linkedDataSignature/types';
 import { ContextEntry } from '@jolocom/protocol-ts';

--- a/js/identity/didDocument/sections/publicKeySection.d.ts
+++ b/js/identity/didDocument/sections/publicKeySection.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 import 'reflect-metadata';
-import { IPublicKeySectionAttrs } from './types';
+import { IPublicKeySectionAttrs } from '@jolocom/protocol-ts';
 export declare class PublicKeySection {
     private _id;
     private _type;

--- a/js/identity/didDocument/sections/serviceEndpointsSection.d.ts
+++ b/js/identity/didDocument/sections/serviceEndpointsSection.d.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { IServiceEndpointSectionAttrs } from './types';
+import { IServiceEndpointSectionAttrs } from '@jolocom/protocol-ts';
 export declare class ServiceEndpointsSection {
     protected _id: string;
     protected _type: string;

--- a/js/identity/didDocument/sections/types.d.ts
+++ b/js/identity/didDocument/sections/types.d.ts
@@ -1,17 +1,1 @@
-import { JsonLdObject } from '../../../linkedData/types';
-export interface IPublicKeySectionAttrs extends JsonLdObject {
-    id: string;
-    type: string;
-    publicKeyHex: string;
-}
-export interface IServiceEndpointSectionAttrs extends JsonLdObject {
-    id: string;
-    type: string;
-    serviceEndpoint: string;
-    description: string;
-}
-export interface IAuthenticationSectionAttrsv0 {
-    publicKey: string;
-    type: string;
-}
-export declare type IAuthenticationSectionAttrs = IPublicKeySectionAttrs | string;
+export { IAuthenticationSectionAttrs, IAuthenticationSectionAttrsv0, IServiceEndpointSectionAttrs, IPublicKeySectionAttrs } from '@jolocom/protocol-ts';

--- a/js/identity/didDocument/types.d.ts
+++ b/js/identity/didDocument/types.d.ts
@@ -1,13 +1,1 @@
-import { IAuthenticationSectionAttrsv0, IAuthenticationSectionAttrs, IPublicKeySectionAttrs, IServiceEndpointSectionAttrs } from './sections/types';
-import { ILinkedDataSignatureAttrs } from '@jolocom/protocol-ts/dist/lib/linkedDataSignature';
-import { ContextEntry } from '@jolocom/protocol-ts';
-export interface IDidDocumentAttrs {
-    '@context': ContextEntry[] | string;
-    specVersion?: number;
-    id: string;
-    authentication?: IAuthenticationSectionAttrsv0[] | IAuthenticationSectionAttrs[];
-    publicKey?: IPublicKeySectionAttrs[];
-    service?: IServiceEndpointSectionAttrs[];
-    created?: string;
-    proof?: ILinkedDataSignatureAttrs;
-}
+export { IDidDocumentAttrs } from '@jolocom/protocol-ts';

--- a/js/identity/identity.d.ts
+++ b/js/identity/identity.d.ts
@@ -1,7 +1,7 @@
+import { IDidDocumentAttrs } from '@jolocom/protocol-ts';
 import { DidDocument } from './didDocument/didDocument';
 import { SignedCredential } from '../credentials/signedCredential/signedCredential';
 import { IIdentityCreateArgs } from './types';
-import { IDidDocumentAttrs } from './didDocument/types';
 import { ISignedCredentialAttrs } from '../credentials/signedCredential/types';
 interface IdentityAttributes {
     didDocument: IDidDocumentAttrs;

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -5,8 +5,8 @@ export declare const JolocomLib: {
     parse: import("./parse/parse").ParseMethods;
     parseAndValidate: {
         interactionToken: (jwt: string, signer: import("./identity/identity").Identity) => Promise<import("./interactionTokens/JSONWebToken").JSONWebToken<import("./interactionTokens/JSONWebToken").JWTEncodable>>;
-        didDocument: (didDocument: import("./identity/didDocument/types").IDidDocumentAttrs) => Promise<import("./identity/didDocument/didDocument").DidDocument>;
-        signedCredential: (signedCredential: import("@jolocom/protocol-ts/dist/lib/signedCredential").ISignedCredentialAttrs, signer: import("./identity/identity").Identity) => Promise<import("./credentials/signedCredential/signedCredential").SignedCredential>;
+        didDocument: (didDocument: import("@jolocom/protocol-ts").IDidDocumentAttrs) => Promise<import("./identity/didDocument/didDocument").DidDocument>;
+        signedCredential: (signedCredential: import("@jolocom/protocol-ts").ISignedCredentialAttrs, signer: import("./identity/identity").Identity) => Promise<import("./credentials/signedCredential/signedCredential").SignedCredential>;
     };
     didMethods: {
         jolo: import("./didMethods/jolo").JoloDidMethod;
@@ -14,10 +14,10 @@ export declare const JolocomLib: {
     };
     KeyProvider: typeof SoftwareKeyProvider;
     util: {
-        constraintFunctions: import("@jolocom/protocol-ts/dist/lib/interactionTokens").IExposedConstraintFunctions;
+        constraintFunctions: import("@jolocom/protocol-ts").IExposedConstraintFunctions;
         fuelKeyWithEther: typeof fuelKeyWithEther;
-        validateDigestable: (toValidate: import("@jolocom/protocol-ts/dist/lib/linkedDataSignature").IDigestable, resolverOrIdentity?: import("./utils/validation").IdentityOrResolver) => Promise<boolean>;
-        validateDigestables: (toValidate: import("@jolocom/protocol-ts/dist/lib/linkedDataSignature").IDigestable[], resolverOrIdentity?: import("./utils/validation").IdentityOrResolver) => Promise<boolean[]>;
+        validateDigestable: (toValidate: import("@jolocom/protocol-ts").IDigestable, resolverOrIdentity?: import("./utils/validation").IdentityOrResolver) => Promise<boolean>;
+        validateDigestables: (toValidate: import("@jolocom/protocol-ts").IDigestable[], resolverOrIdentity?: import("./utils/validation").IdentityOrResolver) => Promise<boolean[]>;
     };
     KeyTypes: typeof KeyTypes;
 };

--- a/js/parse/parseAndValidate.d.ts
+++ b/js/parse/parseAndValidate.d.ts
@@ -1,4 +1,4 @@
-import { IDidDocumentAttrs } from '../identity/didDocument/types';
+import { IDidDocumentAttrs } from '@jolocom/protocol-ts';
 import { DidDocument } from '../identity/didDocument/didDocument';
 import { JWTEncodable, JSONWebToken } from '../interactionTokens/JSONWebToken';
 import { Identity } from '../identity/identity';

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@jolocom/jolo-did-resolver": "^1.0.0",
     "@jolocom/local-resolver-registrar": "^1.0.1",
     "@jolocom/native-core": "^1.0.0",
-    "@jolocom/protocol-ts": "^0.5.1",
+    "@jolocom/protocol-ts": "^0.5.3",
     "@jolocom/vaulted-key-provider": "^0.7.4",
     "@types/sinon": "^9.0.5",
     "bip39": "^3.0.2",

--- a/ts/identity/didDocument/didDocument.ts
+++ b/ts/identity/didDocument/didDocument.ts
@@ -7,7 +7,7 @@ import {
   Transform,
   Type,
 } from 'class-transformer'
-import { IDidDocumentAttrs } from './types'
+import { IDidDocumentAttrs } from '@jolocom/protocol-ts'
 import { EcdsaLinkedDataSignature } from '../../linkedDataSignature'
 import {
   AuthenticationSection,

--- a/ts/identity/didDocument/sections/publicKeySection.ts
+++ b/ts/identity/didDocument/sections/publicKeySection.ts
@@ -6,7 +6,7 @@ import {
   Expose,
   Transform,
 } from 'class-transformer'
-import { IPublicKeySectionAttrs } from './types'
+import { IPublicKeySectionAttrs } from '@jolocom/protocol-ts'
 
 /**
  * Class modelling a Did Document Pulic Key section

--- a/ts/identity/didDocument/sections/serviceEndpointsSection.ts
+++ b/ts/identity/didDocument/sections/serviceEndpointsSection.ts
@@ -6,7 +6,7 @@ import {
   Expose,
   Transform,
 } from 'class-transformer'
-import { IServiceEndpointSectionAttrs } from './types'
+import { IServiceEndpointSectionAttrs } from '@jolocom/protocol-ts'
 
 /**
  * Class modelling a Did Document Service Endpoint section

--- a/ts/identity/didDocument/sections/types.ts
+++ b/ts/identity/didDocument/sections/types.ts
@@ -1,21 +1,8 @@
-import { JsonLdObject } from '../../../linkedData/types'
-
-export interface IPublicKeySectionAttrs extends JsonLdObject {
-  id: string
-  type: string
-  publicKeyHex: string
-}
-
-export interface IServiceEndpointSectionAttrs extends JsonLdObject {
-  id: string
-  type: string
-  serviceEndpoint: string
-  description: string
-}
-
-export interface IAuthenticationSectionAttrsv0 {
-  publicKey: string
-  type: string
-}
-
-export type IAuthenticationSectionAttrs = IPublicKeySectionAttrs | string
+// TODO @next here only for backwards compatibility
+// types moved to @jolocom/protocol-ts
+export {
+  IAuthenticationSectionAttrs,
+  IAuthenticationSectionAttrsv0,
+  IServiceEndpointSectionAttrs,
+  IPublicKeySectionAttrs
+} from '@jolocom/protocol-ts'

--- a/ts/identity/didDocument/types.ts
+++ b/ts/identity/didDocument/types.ts
@@ -1,21 +1,3 @@
-import {
-  IAuthenticationSectionAttrsv0,
-  IAuthenticationSectionAttrs,
-  IPublicKeySectionAttrs,
-  IServiceEndpointSectionAttrs,
-} from './sections/types'
-import { ILinkedDataSignatureAttrs } from '@jolocom/protocol-ts/dist/lib/linkedDataSignature'
-import { ContextEntry } from '@jolocom/protocol-ts'
-
-export interface IDidDocumentAttrs {
-  '@context': ContextEntry[] | string
-  specVersion?: number
-  id: string
-  authentication?:
-    | IAuthenticationSectionAttrsv0[]
-    | IAuthenticationSectionAttrs[]
-  publicKey?: IPublicKeySectionAttrs[]
-  service?: IServiceEndpointSectionAttrs[]
-  created?: string
-  proof?: ILinkedDataSignatureAttrs
-}
+// TODO @next here only for backwards compatibility
+// types moved to @jolocom/protocol-ts
+export { IDidDocumentAttrs } from '@jolocom/protocol-ts'

--- a/ts/identity/identity.ts
+++ b/ts/identity/identity.ts
@@ -1,8 +1,8 @@
+import { IDidDocumentAttrs } from '@jolocom/protocol-ts'
 import { classToPlain, plainToClass, Type, Exclude, Expose } from 'class-transformer'
 import { DidDocument } from './didDocument/didDocument'
 import { SignedCredential } from '../credentials/signedCredential/signedCredential'
 import { IIdentityCreateArgs } from './types'
-import { IDidDocumentAttrs } from './didDocument/types'
 import { ISignedCredentialAttrs } from '../credentials/signedCredential/types'
 
 /**

--- a/ts/parse/parseAndValidate.ts
+++ b/ts/parse/parseAndValidate.ts
@@ -1,4 +1,4 @@
-import { IDidDocumentAttrs } from '../identity/didDocument/types'
+import { IDidDocumentAttrs } from '@jolocom/protocol-ts'
 import { DidDocument } from '../identity/didDocument/didDocument'
 import { JWTEncodable, JSONWebToken } from '../interactionTokens/JSONWebToken'
 import { validateJsonLd } from '../linkedData'

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,10 +690,10 @@
     "@jolocom/native-core-node-14-linux-x64" "^1.0.0"
     "@jolocom/native-core-node-14-win32-x64" "^1.0.0"
 
-"@jolocom/protocol-ts@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@jolocom/protocol-ts/-/protocol-ts-0.5.1.tgz#faa22952029b27d2115be355c4bbf409af00f9c5"
-  integrity sha512-AMnn22qKm+0l840hg3WRioXudxd+1uuJka4oi5vRH4PGinzpEsNoXn5sc4anHy7VbZhwGrBT2UgQEPQYqHP8gQ==
+"@jolocom/protocol-ts@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@jolocom/protocol-ts/-/protocol-ts-0.5.3.tgz#52209f19f92bf9a4d0c0848ec862432d2552f771"
+  integrity sha512-9UN1wzCozW+bsxcfYvkkQvoSBw1qQ/7rNUAOmSm8PhipaHQ2Dij741Eqkw+yA3hn58GchtzQnIsGNN6god8qmQ==
   dependencies:
     cred-types-jolocom-core "^0.0.11"
 


### PR DESCRIPTION
This updates to a version of the protocol that includes `CredentialOffer2` based on https://github.com/jolocom/jolocom-protocol-ts/pull/7